### PR TITLE
Require some basic configuration schema properties

### DIFF
--- a/lib/plugin-yaml-schema.yml
+++ b/lib/plugin-yaml-schema.yml
@@ -14,6 +14,17 @@ properties:
   configuration:
     type: object
     description: "The JSON schema for the plugin’s configuration options. See http://json-schema.org and https://jsonschemalint.com/"
+    properties:
+      properties:
+        type: object
+      required:
+        type: array
+      additionalProperties:
+        type: boolean
+    required:
+      - properties
+      - required
+      - additionalProperties
 required:
   - name
   - description

--- a/test/plugin-yaml-linter.test.js
+++ b/test/plugin-yaml-linter.test.js
@@ -12,50 +12,25 @@ describe('plugin-yaml-linter', () => {
         silent: true
       }))
     })
-  })
-  describe('missing name', () => {
-    it('should be invalid', async () => {
-      assert.isFalse(await linter({
-        name: 'missing-name',
-        path: path.join(fixtures, 'missing-name'),
-        silent: true
-      }))
-    })
-  })
-  describe('missing description', () => {
-    it('should be invalid', async () => {
-      assert.isFalse(await linter({
-        name: 'missing-description',
-        path: path.join(fixtures, 'missing-description'),
-        silent: true
-      }))
-    })
-  })
-  describe('missing author', () => {
-    it('should be invalid', async () => {
-      assert.isFalse(await linter({
-        name: 'missing-author',
-        path: path.join(fixtures, 'missing-author'),
-        silent: true
-      }))
-    })
-  })
-  describe('missing requirements', () => {
-    it('should be invalid', async () => {
-      assert.isFalse(await linter({
-        name: 'missing-requirements',
-        path: path.join(fixtures, 'missing-requirements'),
-        silent: true
-      }))
-    })
-  })
-  describe('missing configuration', () => {
-    it('should be invalid', async () => {
-      assert.isFalse(await linter({
-        name: 'missing-configuration',
-        path: path.join(fixtures, 'missing-configuration'),
-        silent: true
-      }))
+  });
+
+  [ 'missing-name',
+    'missing-description',
+    'missing-author',
+    'missing-requirements',
+    'missing-configuration',
+    'missing-configuration-properties',
+    'missing-configuration-required',
+    'missing-configuration-additional-properties'
+  ].forEach((invalidCase) => {
+    describe(invalidCase, () => {
+      it('should be invalid', async () => {
+        assert.isFalse(await linter({
+          name: invalidCase,
+          path: path.join(fixtures, invalidCase),
+          silent: true
+        }))
+      })
     })
   })
 })

--- a/test/plugin-yaml-linter/missing-author/plugin.yml
+++ b/test/plugin-yaml-linter/missing-author/plugin.yml
@@ -1,4 +1,7 @@
 name: A plugin
 description: A great plugin
 requirements: []
-configuration: {}
+configuration:
+  properties: {}
+  required: []
+  additionalProperties: false

--- a/test/plugin-yaml-linter/missing-configuration-additional-properties/plugin.yml
+++ b/test/plugin-yaml-linter/missing-configuration-additional-properties/plugin.yml
@@ -1,7 +1,7 @@
+name: A plugin
 description: A great plugin
 author: github.com/buildkite
 requirements: []
 configuration:
   properties: {}
   required: []
-  additionalProperties: false

--- a/test/plugin-yaml-linter/missing-configuration-properties/plugin.yml
+++ b/test/plugin-yaml-linter/missing-configuration-properties/plugin.yml
@@ -1,7 +1,7 @@
+name: A plugin
 description: A great plugin
 author: github.com/buildkite
 requirements: []
 configuration:
-  properties: {}
   required: []
   additionalProperties: false

--- a/test/plugin-yaml-linter/missing-configuration-required/plugin.yml
+++ b/test/plugin-yaml-linter/missing-configuration-required/plugin.yml
@@ -1,7 +1,7 @@
+name: A plugin
 description: A great plugin
 author: github.com/buildkite
 requirements: []
 configuration:
   properties: {}
-  required: []
   additionalProperties: false

--- a/test/plugin-yaml-linter/missing-configuration/plugin.yml
+++ b/test/plugin-yaml-linter/missing-configuration/plugin.yml
@@ -1,4 +1,7 @@
 name: A plugin
 description: A great plugin
 author: github.com/buildkite
-requirements: []
+configuration:
+  properties: {}
+  required: []
+  additionalProperties: false

--- a/test/plugin-yaml-linter/missing-description/plugin.yml
+++ b/test/plugin-yaml-linter/missing-description/plugin.yml
@@ -1,4 +1,7 @@
 name: A plugin
 author: github.com/buildkite
 requirements: []
-configuration: {}
+configuration:
+  properties: {}
+  required: []
+  additionalProperties: false

--- a/test/plugin-yaml-linter/missing-requirements/plugin.yml
+++ b/test/plugin-yaml-linter/missing-requirements/plugin.yml
@@ -1,4 +1,7 @@
 name: A plugin
 description: A great plugin
 author: github.com/buildkite
-configuration: {}
+configuration:
+  properties: {}
+  required: []
+  additionalProperties: false

--- a/test/plugin-yaml-linter/valid-plugin/plugin.yml
+++ b/test/plugin-yaml-linter/valid-plugin/plugin.yml
@@ -2,4 +2,7 @@ name: A plugin
 description: A great plugin
 author: github.com/buildkite
 requirements: []
-configuration: {}
+configuration:
+  properties: {}
+  required: []
+  additionalProperties: false


### PR DESCRIPTION
Most importantly, require that `additionalProperties` is explicitly set, to help people catch typos when using a plugin.