### PR TITLE
Support step-less examples

### DIFF
--- a/lib/linters/example-linter.js
+++ b/lib/linters/example-linter.js
@@ -81,17 +81,21 @@ module.exports = async function (argv, tap) {
   function extractPluginConfigs (exampleYaml) {
     const configs = []
     const example = yaml.safeLoad(exampleYaml)
-    if (example.steps) {
-      example.steps.forEach((step) => {
-        if (step.plugins) {
-          Object.entries(step.plugins).forEach(([ name, config ]) => {
-            if (pluginConfigKeyPattern.exec(name)) {
-              configs.push(config)
-            }
-          })
-        }
-      })
+    let steps = example.steps
+    // Some readmes leave off the "steps" key and jump right into an array of
+    // commands.
+    if (!steps) {
+      steps = example
     }
+    steps.forEach((step) => {
+      if (step.plugins) {
+        Object.entries(step.plugins).forEach(([ name, config ]) => {
+          if (pluginConfigKeyPattern.exec(name)) {
+            configs.push(config)
+          }
+        })
+      }
+    })
     return configs
   }
 }

--- a/test/example-linter.test.js
+++ b/test/example-linter.test.js
@@ -27,6 +27,16 @@ describe('example-linter', () => {
       }, tap))
     })
   })
+  describe('valid plugin with examples without a steps key', () => {
+    it('should be valid', async () => {
+      assert(await linter({
+        name: 'valid-example-without-a-steps-key',
+        path: path.join(fixtures, 'valid-example-without-a-steps-key'),
+        silent: true,
+        readme: 'README.md'
+      }, tap))
+    })
+  })
   describe('invalid examples', () => {
     it('should be invalid', async () => {
       assert.isFalse(await linter({

--- a/test/example-linter/valid-example-without-a-steps-key/README.md
+++ b/test/example-linter/valid-example-without-a-steps-key/README.md
@@ -3,6 +3,6 @@
 ```yml
 - label: "Label"
   plugins:
-    valid-plugin#v1.2.3:
+    valid-example-without-a-steps-key#v1.2.3:
       option: value
 ```


### PR DESCRIPTION
Some plugins such as https://github.com/bugcrowd/test-summary-buildkite-plugin don't include the `steps` key in the README.md example, but instead just the array of steps itself.

This adds support for those types of examples.

Closes #10