### PR TITLE
Don't choke on unrelated yml blocks

### DIFF
--- a/lib/linters/example-linter.js
+++ b/lib/linters/example-linter.js
@@ -22,8 +22,6 @@ module.exports = async function (argv, tap) {
   const ajv = new Ajv({ allErrors: true, jsonPointers: true })
   const validator = ajv.compile(pluginYaml.configuration)
 
-  const pluginConfigKeyPattern = new RegExp(`^${name}#v.*$`)
-
   const validConfigs = []
   const invalidConfigs = []
 
@@ -79,23 +77,33 @@ module.exports = async function (argv, tap) {
   }
 
   function extractPluginConfigs (exampleYaml) {
-    const configs = []
+    const pluginPattern = `${name}#v.+`
+    const pluginRegexp = new RegExp(pluginPattern)
+    const pluginStepConfigRegexp = new RegExp(`^${pluginPattern}$`)
+
+    // Ignore any YAML examples that don't mention the plugin
+    if (!pluginRegexp.test(exampleYaml)) {
+      return []
+    }    
+
     const example = yaml.safeLoad(exampleYaml)
-    let steps = example.steps
+
     // Some readmes leave off the "steps" key and jump right into an array of
-    // commands.
-    if (!steps) {
-      steps = example
-    }
+    // commands. In that case, we use the whole example.
+    let steps = example.steps || example
+
+    const configs = []
+
     steps.forEach((step) => {
       if (step.plugins) {
-        Object.entries(step.plugins).forEach(([ name, config ]) => {
-          if (pluginConfigKeyPattern.exec(name)) {
+        Object.entries(step.plugins).forEach(([ key, config ]) => {
+          if (pluginStepConfigRegexp.test(key)) {
             configs.push(config)
           }
         })
       }
     })
+
     return configs
   }
 }

--- a/test/example-linter.test.js
+++ b/test/example-linter.test.js
@@ -37,6 +37,16 @@ describe('example-linter', () => {
       }, tap))
     })
   })
+  describe('valid example with ignored yml block', () => {
+    it('should be valid', async () => {
+      assert(await linter({
+        name: 'valid-example-with-ignored-yml-block',
+        path: path.join(fixtures, 'valid-example-with-ignored-yml-block'),
+        silent: true,
+        readme: 'README.md'
+      }, tap))
+    })
+  })
   describe('invalid examples', () => {
     it('should be invalid', async () => {
       assert.isFalse(await linter({

--- a/test/example-linter/valid-example-with-ignored-yml-block/README.md
+++ b/test/example-linter/valid-example-with-ignored-yml-block/README.md
@@ -1,0 +1,15 @@
+# Example
+
+```yml
+steps:
+  - plugins:
+      valid-example-with-ignored-yml-block#v1.2.3:
+        option: value
+```
+
+```yml
+some:
+  other:
+    yaml:
+      block: ~
+```

--- a/test/example-linter/valid-example-with-ignored-yml-block/plugin.yml
+++ b/test/example-linter/valid-example-with-ignored-yml-block/plugin.yml
@@ -1,0 +1,4 @@
+configuration:
+  properties:
+    option:
+      type: string


### PR DESCRIPTION
#12 introduced supporting step-less examples, but introduced a bug that causes the example validator to choke on bits of yml like this (from the [docker-compose plugin readme](https://github.com/buildkite-plugins/docker-compose-buildkite-plugin)):

```yml
volumes:
  - "./dist:/app/dist"
```

This fixes the example validator by ignoring any yml readme chunks that don't feature something that looks like a plugin identifier (e.g. `org/plugin#v1.0.0`)