### PR TITLE
Better errors for invalid names

### DIFF
--- a/bin/lint
+++ b/bin/lint
@@ -16,6 +16,12 @@ const argv = require('yargs')
     type: 'string',
     default: 'README.md'
   })
+  .check(yargs => {
+    if (yargs && yargs.name && yargs.name.endsWith('-buildkite-plugin')) {
+      throw new Error(`--name can not end with -buildkite-plugin. Did you mean ${yargs.name.replace(/-buildkite-plugin$/, '')}?`)
+    }
+    return true
+  })
   .demandOption(['name', 'path'])
   .help()
   .version(false)


### PR DESCRIPTION
In jobready/codeclimate-test-reporter-buildkite-plugin#4 it became clear the --name arg usage is a bit unclear with our repo naming conventions.

This adds a more useful error message, for example:

```
--name can not end with -buildkite-plugin. Did you mean jobready/codeclimate-test-reporter?
```