### PR TITLE
Switch to --id, to differentiate from plugin.yml name

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ or you can add it to your docker-compose.yml file and then use `docker-compose r
 services:
   lint:
     image: buildkite/plugin-linter
-    command: ['--name', 'my-org/my-plugin']
+    command: ['--id', 'my-org/my-plugin']
     volumes:
       - ".:/plugin"
  ```
@@ -37,7 +37,7 @@ docker run \
   --rm \
   -v "$(pwd):/plugin" \
   buildkite/plugin-linter \
-    --name my-org/my-plugin
+    --id my-org/my-plugin
 ```
 
 ## Roadmap / TODO

--- a/bin/lint
+++ b/bin/lint
@@ -3,9 +3,10 @@
 const argv = require('yargs')
   .env('PLUGIN')
   .usage('$0', 'Lint a buildkite plugin')
-  .option('name', {
-    describe: 'Name of the plugin',
-    type: 'string'
+  .option('id', {
+    describe: 'Id of the plugin (e.g. my-org/my-plugin)',
+    type: 'string',
+    alias: 'name'
   })
   .option('path', {
     describe: 'Path to the plugin',
@@ -17,12 +18,12 @@ const argv = require('yargs')
     default: 'README.md'
   })
   .check(yargs => {
-    if (yargs && yargs.name && yargs.name.endsWith('-buildkite-plugin')) {
-      throw new Error(`--name can not end with -buildkite-plugin. Did you mean ${yargs.name.replace(/-buildkite-plugin$/, '')}?`)
+    if (yargs && yargs.id && yargs.id.endsWith('-buildkite-plugin')) {
+      throw new Error(`--id can not end with -buildkite-plugin. Did you mean ${yargs.id.replace(/-buildkite-plugin$/, '')}?`)
     }
     return true
   })
-  .demandOption(['name', 'path'])
+  .demandOption(['id', 'path'])
   .help()
   .version(false)
   .argv

--- a/lib/linters/example-linter.js
+++ b/lib/linters/example-linter.js
@@ -5,7 +5,7 @@ const yaml = require('js-yaml')
 const pluginYamlParser = require('../plugin-yaml')
 
 module.exports = async function (argv, tap) {
-  const { name, path: pluginPath, readme, silent } = argv
+  const { id, path: pluginPath, readme, silent } = argv
 
   const readmePath = path.join(pluginPath, readme)
 
@@ -77,7 +77,7 @@ module.exports = async function (argv, tap) {
   }
 
   function extractPluginConfigs (exampleYaml) {
-    const pluginPattern = `${name}#v.+`
+    const pluginPattern = `${id}#v.+`
     const pluginRegexp = new RegExp(pluginPattern)
     const pluginStepConfigRegexp = new RegExp(`^${pluginPattern}$`)
 

--- a/lib/linters/readme-version-number-linter.js
+++ b/lib/linters/readme-version-number-linter.js
@@ -4,9 +4,9 @@ const git = require('isomorphic-git')
 const compareVersions = require('compare-versions')
 
 module.exports = async function (argv, tap) {
-  const { name, path: pluginPath, readme, silent } = argv
+  const { id, path: pluginPath, readme, silent } = argv
 
-  const pluginConfigKeyPattern = new RegExp(`${name}#(v.*):`, 'g')
+  const pluginConfigKeyPattern = new RegExp(`${id}#(v.*):`, 'g')
 
   const readmePath = path.join(pluginPath, readme)
   const readmeContents = fs.readFileSync(readmePath, 'utf8')

--- a/test/example-linter.test.js
+++ b/test/example-linter.test.js
@@ -10,7 +10,7 @@ describe('example-linter', () => {
   describe('valid example', () => {
     it('should be valid', async () => {
       assert(await linter({
-        name: 'valid-plugin',
+        id: 'valid-plugin',
         path: path.join(fixtures, 'valid-plugin'),
         silent: true,
         readme: 'README.md'
@@ -20,7 +20,7 @@ describe('example-linter', () => {
   describe('valid plugin with yaml instead of yml', () => {
     it('should be valid', async () => {
       assert(await linter({
-        name: 'valid-plugin-with-yaml',
+        id: 'valid-plugin-with-yaml',
         path: path.join(fixtures, 'valid-plugin-with-yaml'),
         silent: true,
         readme: 'README.md'
@@ -30,7 +30,7 @@ describe('example-linter', () => {
   describe('valid plugin with examples without a steps key', () => {
     it('should be valid', async () => {
       assert(await linter({
-        name: 'valid-example-without-a-steps-key',
+        id: 'valid-example-without-a-steps-key',
         path: path.join(fixtures, 'valid-example-without-a-steps-key'),
         silent: true,
         readme: 'README.md'
@@ -40,7 +40,7 @@ describe('example-linter', () => {
   describe('valid example with ignored yml block', () => {
     it('should be valid', async () => {
       assert(await linter({
-        name: 'valid-example-with-ignored-yml-block',
+        id: 'valid-example-with-ignored-yml-block',
         path: path.join(fixtures, 'valid-example-with-ignored-yml-block'),
         silent: true,
         readme: 'README.md'
@@ -50,7 +50,7 @@ describe('example-linter', () => {
   describe('invalid examples', () => {
     it('should be invalid', async () => {
       assert.isFalse(await linter({
-        name: 'invalid-examples',
+        id: 'invalid-examples',
         path: path.join(fixtures, 'invalid-examples'),
         silent: true,
         readme: 'README.md'
@@ -60,7 +60,7 @@ describe('example-linter', () => {
   describe('custom readme paths', () => {
     it('should work', async () => {
       assert(await linter({
-        name: 'custom-readme',
+        id: 'custom-readme',
         path: path.join(fixtures, 'custom-readme'),
         silent: true,
         readme: 'custom-readme.md'
@@ -70,7 +70,7 @@ describe('example-linter', () => {
   describe('skips validation if missing .configuration', () => {
     it('should work', async () => {
       assert(await linter({
-        name: 'missing-configuration',
+        id: 'missing-configuration',
         path: path.join(fixtures, 'missing-configuration'),
         silent: true,
         readme: 'README.md'

--- a/test/plugin-yaml-linter.test.js
+++ b/test/plugin-yaml-linter.test.js
@@ -10,7 +10,7 @@ describe('plugin-yaml-linter', () => {
   describe('valid plugin', () => {
     it('should be valid', async () => {
       assert(await linter({
-        name: 'valid-plugin',
+        id: 'valid-plugin',
         path: path.join(fixtures, 'valid-plugin'),
         silent: true
       }, tap))

--- a/test/readme-version-number-linter.test.js
+++ b/test/readme-version-number-linter.test.js
@@ -20,7 +20,7 @@ describe('readme-version-number-linter', () => {
   describe('readme with current version numbers', () => {
     it('should be valid', async () => {
       assert(await linter({
-        name: 'up-to-date',
+        id: 'up-to-date',
         path: initGitFixture(path.join(fixtures, 'up-to-date')),
         readme: 'README.md',
         silent: true
@@ -30,7 +30,7 @@ describe('readme-version-number-linter', () => {
   describe('readme with higher version numbers', () => {
     it('should be valid', async () => {
       assert(await linter({
-        name: 'future-version',
+        id: 'future-version',
         path: initGitFixture(path.join(fixtures, 'future-version')),
         readme: 'README.md',
         silent: true
@@ -40,7 +40,7 @@ describe('readme-version-number-linter', () => {
   describe('custom readme with current version numbers', () => {
     it('should be valid', async () => {
       assert(linter({
-        name: 'custom-readme',
+        id: 'custom-readme',
         path: initGitFixture(path.join(fixtures, 'custom-readme')),
         readme: 'custom-readme.md',
         silent: true
@@ -50,7 +50,7 @@ describe('readme-version-number-linter', () => {
   describe('readme with out of date version numbers', () => {
     it('should be invalid', async () => {
       assert.isFalse(await linter({
-        name: 'out-of-date',
+        id: 'out-of-date',
         path: initGitFixture(path.join(fixtures, 'out-of-date')),
         readme: 'README.md',
         silent: true


### PR DESCRIPTION
Related to #15, this changes `--name` to `--id` so we can switch to plain English names.