### PR TITLE
Add plugin id to lint error outputs

### DIFF
--- a/lib/linters/example-linter.js
+++ b/lib/linters/example-linter.js
@@ -40,7 +40,7 @@ module.exports = async function (argv, tap) {
 
   if (!validConfigs.length && !invalidConfigs.length) {
     if (!silent) {
-      tap.fail(`Readme must have at least one config example`, {
+      tap.fail(`Readme must have at least one config example matching plugin id '${id}'`, {
         at: false,
         stack: false
       })
@@ -48,7 +48,7 @@ module.exports = async function (argv, tap) {
     return false
   } else if (invalidConfigs.length) {
     if (!silent) {
-      tap.fail(`Some readme config examples are invalid`, {
+      tap.fail(`Some readme config examples for plugin id '${id}' are invalid`, {
         'invalid configs': invalidConfigs,
         at: false
       })
@@ -56,7 +56,7 @@ module.exports = async function (argv, tap) {
     return false
   } else {
     if (!silent) {
-      tap.pass(`Readme config examples are valid (${validConfigs.length} found)`)
+      tap.pass(`All the readme config examples for plugin id '${id}' are valid (${validConfigs.length} found)`)
     }
     return true
   }

--- a/lib/linters/example-linter.js
+++ b/lib/linters/example-linter.js
@@ -40,7 +40,7 @@ module.exports = async function (argv, tap) {
 
   if (!validConfigs.length && !invalidConfigs.length) {
     if (!silent) {
-      tap.fail(`Readme must have at least one config example matching plugin id '${id}'`, {
+      tap.fail(`No readme config examples found with plugin id '${id}'. Have you configured the linter with the correct plugin id?`, {
         at: false,
         stack: false
       })


### PR DESCRIPTION
It's easy to forget to update the plugin id when running the plugin linter. This makes the error output a little better, so you know what might have gone wrong.