### PR TITLE
Require plugin examples to be arrays

### DIFF
--- a/lib/linters/example-linter.js
+++ b/lib/linters/example-linter.js
@@ -96,10 +96,22 @@ module.exports = async function (argv, tap) {
 
     steps.forEach((step) => {
       if (step.plugins) {
-        Object.entries(step.plugins).forEach(([ key, config ]) => {
-          if (pluginStepConfigRegexp.test(key)) {
-            configs.push(config)
-          }
+        // The old plugins syntax was to use a map, but the new one is an Array.
+        // We fail on anything other than array now.
+        if (!(step.plugins instanceof Array)) {
+          tap.fail(`Plugins list should be an array, not a map`, {
+            example: example,
+            at: false,
+            stack: false
+          })
+        }
+
+        (step.plugins).forEach(pluginMap => {
+          Object.entries(pluginMap).forEach(([ key, config ]) => {
+            if (pluginStepConfigRegexp.test(key)) {
+              configs.push(config)
+            }
+          })
         })
       }
     })

--- a/test/example-linter.test.js
+++ b/test/example-linter.test.js
@@ -57,6 +57,16 @@ describe('example-linter', () => {
       }, tap))
     })
   })
+  describe('old plugin syntax', () => {
+    it('should be invalid', async () => {
+      assert.isFalse(await linter({
+        id: 'invalid-examples',
+        path: path.join(fixtures, 'old-plugins-syntax'),
+        silent: true,
+        readme: 'README.md'
+      }, tap))
+    })
+  })
   describe('custom readme paths', () => {
     it('should work', async () => {
       assert(await linter({

--- a/test/example-linter/custom-readme/custom-readme.md
+++ b/test/example-linter/custom-readme/custom-readme.md
@@ -3,6 +3,6 @@
 ```yml
 steps:
   - plugins:
-      custom-readme#v1.2.3:
-        option: value
+      - custom-readme#v1.2.3:
+          option: value
 ```

--- a/test/example-linter/invalid-examples/README.md
+++ b/test/example-linter/invalid-examples/README.md
@@ -3,6 +3,6 @@
 ```yml
 steps:
   - plugins:
-      invalid-plugin#v1.2.3:
-        bad: value
+      - invalid-plugin#v1.2.3:
+          bad: value
 ```

--- a/test/example-linter/missing-configuration/README.md
+++ b/test/example-linter/missing-configuration/README.md
@@ -3,6 +3,6 @@
 ```yml
 steps:
   - plugins:
-      missing-schema#v1.2.3:
-        option: value
+      - missing-schema#v1.2.3:
+          option: value
 ```

--- a/test/example-linter/old-plugins-syntax/README.md
+++ b/test/example-linter/old-plugins-syntax/README.md
@@ -1,0 +1,8 @@
+# Example
+
+```yml
+steps:
+  - plugins:
+      valid-plugin#v1.2.3:
+        option: value
+```

--- a/test/example-linter/old-plugins-syntax/plugin.yml
+++ b/test/example-linter/old-plugins-syntax/plugin.yml
@@ -1,0 +1,4 @@
+configuration:
+  properties:
+    option:
+      type: string

--- a/test/example-linter/valid-example-with-ignored-yml-block/README.md
+++ b/test/example-linter/valid-example-with-ignored-yml-block/README.md
@@ -3,8 +3,8 @@
 ```yml
 steps:
   - plugins:
-      valid-example-with-ignored-yml-block#v1.2.3:
-        option: value
+      - valid-example-with-ignored-yml-block#v1.2.3:
+          option: value
 ```
 
 ```yml

--- a/test/example-linter/valid-example-without-a-steps-key/README.md
+++ b/test/example-linter/valid-example-without-a-steps-key/README.md
@@ -3,6 +3,6 @@
 ```yml
 - label: "Label"
   plugins:
-    valid-example-without-a-steps-key#v1.2.3:
-      option: value
+    - valid-example-without-a-steps-key#v1.2.3:
+        option: value
 ```

--- a/test/example-linter/valid-plugin-with-yaml/README.md
+++ b/test/example-linter/valid-plugin-with-yaml/README.md
@@ -3,6 +3,6 @@
 ```yaml
 steps:
   - plugins:
-      valid-plugin-with-yaml#v1.2.3:
-        option: value
+      - valid-plugin-with-yaml#v1.2.3:
+          option: value
 ```

--- a/test/example-linter/valid-plugin/README.md
+++ b/test/example-linter/valid-plugin/README.md
@@ -3,6 +3,6 @@
 ```yml
 steps:
   - plugins:
-      valid-plugin#v1.2.3:
-        option: value
+      - valid-plugin#v1.2.3:
+          option: value
 ```

--- a/test/readme-version-number-linter/custom-readme/custom-readme.md
+++ b/test/readme-version-number-linter/custom-readme/custom-readme.md
@@ -1,3 +1,3 @@
 steps:
   - plugins:
-      custom-readme#v1.0.0: ~
+      - custom-readme#v1.0.0: ~

--- a/test/readme-version-number-linter/future-version/README.md
+++ b/test/readme-version-number-linter/future-version/README.md
@@ -1,3 +1,3 @@
 steps:
   - plugins:
-      future-version#v2.0.0: ~
+      - future-version#v2.0.0: ~

--- a/test/readme-version-number-linter/invalid-sem-ver-tags/README.md
+++ b/test/readme-version-number-linter/invalid-sem-ver-tags/README.md
@@ -1,3 +1,3 @@
 steps:
   - plugins:
-      invalid-sem-ver-tags#v0.2.0: ~  
+      - invalid-sem-ver-tags#v0.2.0: ~  

--- a/test/readme-version-number-linter/out-of-date/README.md
+++ b/test/readme-version-number-linter/out-of-date/README.md
@@ -1,3 +1,3 @@
 steps:
   - plugins:
-      out-of-date#v0.0.1: ~
+      - out-of-date#v0.0.1: ~

--- a/test/readme-version-number-linter/up-to-date/README.md
+++ b/test/readme-version-number-linter/up-to-date/README.md
@@ -1,3 +1,3 @@
 steps:
   - plugins:
-      up-to-date#v1.0.0: ~
+      - up-to-date#v1.0.0: ~


### PR DESCRIPTION
The new recommended way to specify plugins in `pipeline.yml` files is as arrays. This updates the linter to fail if it's not the array version.

For example, the following is valid:

 ```yml
steps:
  - plugins:
      - valid-plugin#v1.2.3:
          option: value
```

whereas the following (old syntax) is now invalid:

 ```yml
steps:
  - plugins:
      valid-plugin#v1.2.3:
        option: value
```