### PR TITLE
Support plugins and examples with git URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ docker run \
     --id my-org/my-plugin
 ```
 
+If your plugin examples use a full git URL, such as `ssh://git@github.com/my-org/example-buildkite-plugin`, then you should specify the full git URL in the `id` argument.
+
 ## Roadmap / TODO
 
 * Check that all the config options in the readme exist in the configuration schema

--- a/bin/lint
+++ b/bin/lint
@@ -18,7 +18,7 @@ const argv = require('yargs')
     default: 'README.md'
   })
   .check(yargs => {
-    if (yargs && yargs.id && yargs.id.endsWith('-buildkite-plugin')) {
+    if (yargs && yargs.id && yargs.id.endsWith('-buildkite-plugin') && yargs.id.indexOf('://') === -1) {
       throw new Error(`--id can not end with -buildkite-plugin. Did you mean ${yargs.id.replace(/-buildkite-plugin$/, '')}?`)
     }
     return true

--- a/test/example-linter.test.js
+++ b/test/example-linter.test.js
@@ -47,6 +47,16 @@ describe('example-linter', () => {
       }, tap))
     })
   })
+  describe('valid example with SSH syntax', () => {
+    it('should be valid', async () => {
+      assert(await linter({
+        id: 'ssh://git@github.com/my-org/example-buildkite-plugin',
+        path: path.join(fixtures, 'valid-plugin-with-ssh-syntax'),
+        silent: false,
+        readme: 'README.md'
+      }, tap))
+    })
+  })
   describe('invalid examples', () => {
     it('should be invalid', async () => {
       assert.isFalse(await linter({

--- a/test/example-linter/valid-plugin-with-ssh-syntax/README.md
+++ b/test/example-linter/valid-plugin-with-ssh-syntax/README.md
@@ -1,0 +1,8 @@
+# Example
+
+```yaml
+steps:
+  - plugins:
+      - ssh://git@github.com/my-org/example-buildkite-plugin#v1.2.3:
+          option: value
+```

--- a/test/example-linter/valid-plugin-with-ssh-syntax/plugin.yml
+++ b/test/example-linter/valid-plugin-with-ssh-syntax/plugin.yml
@@ -1,0 +1,4 @@
+configuration:
+  properties:
+    option:
+      type: string


### PR DESCRIPTION
If you plugin examples use full Git URLs, such as `ssh://git@github.com/my-org/example-buildkite-plugin`, then currently you're unable to lint your plugin, as it can't be provided to the `id` argument.

This adds support for these plugins, by letting you set the `id` argument to the full URL.

Fixes #208