### PR TITLE
feat: Add linter support for plugins with no config

### DIFF
--- a/lib/linters/example-linter.js
+++ b/lib/linters/example-linter.js
@@ -107,6 +107,10 @@ module.exports = async function (argv, tap) {
         }
 
         (step.plugins).forEach(pluginMap => {
+          if (typeof pluginMap === "string" && pluginStepConfigRegexp.test(pluginMap)) {
+            configs.push(null);
+            return;
+          }
           Object.entries(pluginMap).forEach(([ key, config ]) => {
             if (pluginStepConfigRegexp.test(key)) {
               configs.push(config)

--- a/lib/linters/example-linter.js
+++ b/lib/linters/example-linter.js
@@ -108,8 +108,8 @@ module.exports = async function (argv, tap) {
 
         (step.plugins).forEach(pluginMap => {
           if (typeof pluginMap === "string" && pluginStepConfigRegexp.test(pluginMap)) {
-            configs.push(null);
-            return;
+            configs.push(null)
+            return
           }
           Object.entries(pluginMap).forEach(([ key, config ]) => {
             if (pluginStepConfigRegexp.test(key)) {

--- a/test/example-linter.test.js
+++ b/test/example-linter.test.js
@@ -27,6 +27,16 @@ describe('example-linter', () => {
       }, tap))
     })
   })
+  describe('valid plugin with zero config', () => {
+    it('should be valid', async () => {
+      assert(await linter({
+        id: 'zero-config-plugin',
+        path: path.join(fixtures, 'zero-config-plugin'),
+        silent: true,
+        readme: 'README.md'
+      }, tap))
+    })
+  })
   describe('valid plugin with examples without a steps key', () => {
     it('should be valid', async () => {
       assert(await linter({

--- a/test/example-linter/zero-config-plugin/README.md
+++ b/test/example-linter/zero-config-plugin/README.md
@@ -1,0 +1,7 @@
+# Example
+
+```yaml
+steps:
+  - plugins:
+      - zero-config-plugin#v1.2.3
+```

--- a/test/example-linter/zero-config-plugin/plugin.yml
+++ b/test/example-linter/zero-config-plugin/plugin.yml
@@ -1,0 +1,2 @@
+configuration:
+  properties: {}


### PR DESCRIPTION
We (at [SEEK-Jobs](https://github.com/SEEK-Jobs)) noticed an issue where a plugin with example yaml that has no config and expressed as a string, and not an empty object, would cause the linter to fail.

This was surprising considering I've seen it working in [this plugin](https://github.com/seek-oss/docker-ecr-cache-buildkite-plugin).

Turns out the linter _alway expects_ a plugin be a yaml object. This PR adds a feature so that that a plugin may also be a yaml string.

## Example:

Works
```
steps:
  - plugins:
      - zero-config-plugin#v1.2.3:
```

Doesn't work (but works with this PR)
```
steps:
  - plugins:
      - zero-config-plugin#v1.2.3
```