### PR TITLE
Add Support for `group` Steps

### DIFF
--- a/lib/linters/example-linter.js
+++ b/lib/linters/example-linter.js
@@ -92,10 +92,14 @@ module.exports = async function (argv, tap) {
     // commands. In that case, we use the whole example.
     let steps = example.steps || example
 
+    // Some examples nest their steps under a group step in which case we lint
+    // the steps _inside_ the group step
+    steps = steps.flatMap((step) => step.group && step.steps || step)
+
     const configs = []
 
     // Flatten group steps before processing
-    steps.flatMap((step) => step.group && step.steps || step).forEach((step) => {
+    steps.forEach((step) => {
       if (step.plugins) {
         // The old plugins syntax was to use a map, but the new one is an Array.
         // We fail on anything other than array now.

--- a/lib/linters/example-linter.js
+++ b/lib/linters/example-linter.js
@@ -94,7 +94,8 @@ module.exports = async function (argv, tap) {
 
     const configs = []
 
-    steps.forEach((step) => {
+    // Flatten group steps before processing
+    steps.flatMap((step) => step.group && step.steps || step).forEach((step) => {
       if (step.plugins) {
         // The old plugins syntax was to use a map, but the new one is an Array.
         // We fail on anything other than array now.

--- a/test/example-linter.test.js
+++ b/test/example-linter.test.js
@@ -37,6 +37,16 @@ describe('example-linter', () => {
       }, tap))
     })
   })
+  describe('valid plugin with examples with group step', () => {
+    it('should be valid', async () => {
+      assert(await linter({
+        id: 'valid-example-with-group-step',
+        path: path.join(fixtures, 'valid-example-with-group-step'),
+        silent: true,
+        readme: 'README.md'
+      }, tap))
+    })
+  })
   describe('valid plugin with examples without a steps key', () => {
     it('should be valid', async () => {
       assert(await linter({

--- a/test/example-linter/valid-example-with-group-step/README.md
+++ b/test/example-linter/valid-example-with-group-step/README.md
@@ -1,0 +1,9 @@
+# Example
+
+```yml
+- group: My Group
+  steps:
+  - plugins:
+      - valid-example-with-group-step#v1.2.3:
+          option: value
+```

--- a/test/example-linter/valid-example-with-group-step/plugin.yml
+++ b/test/example-linter/valid-example-with-group-step/plugin.yml
@@ -1,0 +1,4 @@
+configuration:
+  properties:
+    option:
+      type: string


### PR DESCRIPTION
We have a plugin where it's useful to show an example with a `group` step (since our plugin itself emits a group of steps).

Previously - the linter did not detect the example step if it was nested in a group.