### PR TITLE
Change url and version validation

### DIFF
--- a/bin/lint
+++ b/bin/lint
@@ -18,7 +18,8 @@ const argv = require('yargs')
     default: 'README.md'
   })
   .check(yargs => {
-    if (yargs && yargs.id && yargs.id.endsWith('-buildkite-plugin') && yargs.id.indexOf('://') === -1) {
+    if (yargs && yargs.id && yargs.id.endsWith('-buildkite-plugin') && yargs.id.indexOf('://') === -1 
+        && !yargs.id.startsWith('./') && !yargs.id.startsWith('/') && !yargs.id.startsWith('~/') ) {
       throw new Error(`--id can not end with -buildkite-plugin. Did you mean ${yargs.id.replace(/-buildkite-plugin$/, '')}?`)
     }
     return true

--- a/lib/linters/example-linter.js
+++ b/lib/linters/example-linter.js
@@ -33,7 +33,7 @@ module.exports = async function (argv, tap) {
           if (valid) {
             validConfigs.push(config)
           } else {
-            invalidConfigs.push({ config: config, errors: validator.errors })
+            invalidConfigs.push({ config, errors: validator.errors })
           }
         })
     })
@@ -82,19 +82,19 @@ module.exports = async function (argv, tap) {
    * @param {string} pluginSpec The plugin spec to test
    * @param {string} id The plugin identifier
    */
-  function matchValidPlugin(pluginSpec, id) {
+  function matchValidPlugin (pluginSpec, id) {
     if (isLocalPlugin(pluginSpec)) {
       // local plugins just need to end with the id, optionally -buildkite-plugin and the hash is ignored
-      pluginRegexp = new RegExp(`${id}(-buildkite-plugin)?(#.+)?$`)
+      const pluginRegexp = new RegExp(`${id}(-buildkite-plugin)?(#.+)?$`)
       return pluginRegexp.test(pluginSpec)
     }
 
-    let pluginRef, expectedPath;
+    let pluginRef, expectedPath
     try {
       // full URL plugins
       pluginRef = new URL(pluginSpec)
       expectedPath = `/${id}-buildkite-plugin`
-    } catch(err) {
+    } catch (err) {
       // assume it is just the name, build the URL (almost) and try again
       pluginRef = new URL(`https://github.com/${pluginSpec}`)
       expectedPath = `/${id}`
@@ -117,7 +117,7 @@ module.exports = async function (argv, tap) {
 
     // Some examples nest their steps under a group step in which case we lint
     // the steps _inside_ the group step
-    steps = steps.flatMap((step) => step.group && step.steps || step)
+    steps = steps.flatMap((step) => (step.group && step.steps) || step)
 
     const configs = []
 
@@ -128,11 +128,11 @@ module.exports = async function (argv, tap) {
         // We ignore non-array ones now.
         if (step.plugins instanceof Array) {
           (step.plugins).forEach(pluginMap => {
-            if (typeof pluginMap === "string" && matchValidPlugin(pluginMap, id)) {
+            if (typeof pluginMap === 'string' && matchValidPlugin(pluginMap, id)) {
               configs.push(null)
               return
             }
-            Object.entries(pluginMap).forEach(([ key, config ]) => {
+            Object.entries(pluginMap).forEach(([key, config]) => {
               if (matchValidPlugin(key, id)) {
                 configs.push(config)
               }
@@ -150,7 +150,7 @@ module.exports = async function (argv, tap) {
    *
    * @param {string} id The plugin identifier
    */
-  function isLocalPlugin(id) {
-    return id.startsWith('/') || id.startsWith('./') || id.startsWith('~/');
+  function isLocalPlugin (id) {
+    return id.startsWith('/') || id.startsWith('./') || id.startsWith('~/')
   }
 }

--- a/lib/linters/example-linter.js
+++ b/lib/linters/example-linter.js
@@ -76,21 +76,44 @@ module.exports = async function (argv, tap) {
     return examples
   }
 
+  /**
+   * Whether the given plugin spec matches the provided plugin id
+   *
+   * @param {string} pluginSpec The plugin spec to test
+   * @param {string} id The plugin identifier
+   */
+  function matchValidPlugin(pluginSpec, id) {
+    if (isLocalPlugin(pluginSpec)) {
+      // local plugins just need to end with the id, optionally -buildkite-plugin and the hash is ignored
+      pluginRegexp = new RegExp(`${id}(-buildkite-plugin)?(#.+)?$`)
+      return pluginRegexp.test(pluginSpec)
+    }
+
+    let pluginRef, expectedPath;
+    try {
+      // full URL plugins
+      pluginRef = new URL(pluginSpec)
+      expectedPath = `/${id}-buildkite-plugin`
+    } catch(err) {
+      // assume it is just the name, build the URL (almost) and try again
+      pluginRef = new URL(`https://github.com/${pluginSpec}`)
+      expectedPath = `/${id}`
+    }
+
+    return pluginRef.pathname === expectedPath && pluginRef.hash.startsWith('#v')
+  }
+
   function extractPluginConfigs (exampleYaml) {
-    const pluginPattern = isLocalPlugin(id) ? `${id}(#.+)?` : `${id}#v.+`
-    const pluginRegexp = new RegExp(pluginPattern)
-    const pluginStepConfigRegexp = new RegExp(`^${pluginPattern}$`)
-
-    // Ignore any YAML examples that don't mention the plugin
-    if (!pluginRegexp.test(exampleYaml)) {
-      return []
-    }    
-
     const example = yaml.safeLoad(exampleYaml)
 
     // Some readmes leave off the "steps" key and jump right into an array of
     // commands. In that case, we use the whole example.
     let steps = example.steps || example
+
+    // if not an array, flatMap will fail
+    if (!(steps instanceof Array)) {
+      steps = [steps]
+    }
 
     // Some examples nest their steps under a group step in which case we lint
     // the steps _inside_ the group step
@@ -109,19 +132,19 @@ module.exports = async function (argv, tap) {
             at: false,
             stack: false
           })
-        }
-
-        (step.plugins).forEach(pluginMap => {
-          if (typeof pluginMap === "string" && pluginStepConfigRegexp.test(pluginMap)) {
-            configs.push(null)
-            return
-          }
-          Object.entries(pluginMap).forEach(([ key, config ]) => {
-            if (pluginStepConfigRegexp.test(key)) {
-              configs.push(config)
+        } else {
+          (step.plugins).forEach(pluginMap => {
+            if (typeof pluginMap === "string" && matchValidPlugin(pluginMap, id)) {
+              configs.push(null)
+              return
             }
+            Object.entries(pluginMap).forEach(([ key, config ]) => {
+              if (matchValidPlugin(key, id)) {
+                configs.push(config)
+              }
+            })
           })
-        })
+        }
       }
     })
 

--- a/lib/linters/example-linter.js
+++ b/lib/linters/example-linter.js
@@ -124,15 +124,9 @@ module.exports = async function (argv, tap) {
     // Flatten group steps before processing
     steps.forEach((step) => {
       if (step.plugins) {
-        // The old plugins syntax was to use a map, but the new one is an Array.
-        // We fail on anything other than array now.
-        if (!(step.plugins instanceof Array)) {
-          tap.fail(`Plugins list should be an array, not a map`, {
-            example: example,
-            at: false,
-            stack: false
-          })
-        } else {
+        // The old (pre-2019) plugins syntax was to use a map
+        // We ignore non-array ones now.
+        if (step.plugins instanceof Array) {
           (step.plugins).forEach(pluginMap => {
             if (typeof pluginMap === "string" && matchValidPlugin(pluginMap, id)) {
               configs.push(null)

--- a/lib/linters/readme-version-number-linter.js
+++ b/lib/linters/readme-version-number-linter.js
@@ -19,7 +19,12 @@ module.exports = async function (argv, tap) {
     return compareVersions(t1, t2) // both are valid, let the module decide
   })
 
-  const latestVersion = sortedTags[sortedTags.length - 1]
+  const latestVersion = sortedTags.pop()
+
+  if (!validate(latestVersion)) {
+    tap.skip('There are no valid tags to compare to')
+    return true
+  }
 
   const invalidVersionNumbers = []
 

--- a/lib/linters/readme-version-number-linter.js
+++ b/lib/linters/readme-version-number-linter.js
@@ -29,7 +29,7 @@ module.exports = async function (argv, tap) {
       break
     }
     const version = match[1]
-    if (version < latestVersion) {
+    if (!validate(version) || compareVersions(version, latestVersion) === -1) {
       invalidVersionNumbers.push(version)
     }
   }

--- a/package.json
+++ b/package.json
@@ -16,10 +16,5 @@
   "scripts": {
     "test": "mocha",
     "lint": "standard"
-  },
-  "standard": {
-    "ignore": [
-      "lib/linters/example-linter.js"
-    ]
   }
 }

--- a/test/example-linter.test.js
+++ b/test/example-linter.test.js
@@ -98,7 +98,7 @@ describe('example-linter', () => {
   describe('old plugin syntax', () => {
     it('should be invalid', async () => {
       assert.isFalse(await linter({
-        id: 'invalid-examples',
+        id: 'valid-plugin',
         path: path.join(fixtures, 'old-plugins-syntax'),
         silent: true,
         readme: 'README.md'

--- a/test/example-linter.test.js
+++ b/test/example-linter.test.js
@@ -70,7 +70,7 @@ describe('example-linter', () => {
   describe('valid example with SSH syntax', () => {
     it('should be valid', async () => {
       assert(await linter({
-        id: 'ssh://git@github.com/my-org/example-buildkite-plugin',
+        id: 'my-org/example',
         path: path.join(fixtures, 'valid-plugin-with-ssh-syntax'),
         silent: true,
         readme: 'README.md'

--- a/test/example-linter/valid-example-with-group-step/README.md
+++ b/test/example-linter/valid-example-with-group-step/README.md
@@ -7,3 +7,12 @@
       - valid-example-with-group-step#v1.2.3:
           option: value
 ```
+
+```yml
+steps:
+- group: My Group
+  steps:
+  - plugins:
+      - valid-example-with-group-step#v1.2.3:
+          option: value
+```


### PR DESCRIPTION
~~*Important*: this PR is built on top of #456~~

This changes ~3~ 5 important things:
1- vendored plugins can have whatever name they want (previously, they couldn't end in `buildkite-plugin` - closes #447 )
2- full URLs are parsed correctly to extract the plugin id (closes #385)
3- if plugins are not specified as an array, they will be completely ignored (see #457  )
4- now we use the versions library correctly when comparing versions extracted from the readme
5- we now validate both extracted versions as well as the tag we are comparing to

While I was making those changes, I also removed the example linter from the exceptions of the standard linter and corrected all warnings