### PR TITLE
Ignore invalid versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,39 @@ Further reading and tools:
 * [JSON Schema](http://json-schema.org)
 * [JSON Schema Lint](https://jsonschemalint.com/)
 
+## Configuration
+
+Options available on the executable as long-form switches (`--OPTION`) can also be passed through as environment variables with the `PLUGIN_` prefix (`PLUGIN_OPTION`).
+
+### Required
+
+#### `id` (string, `PLUGIN_ID`)
+
+This is the id of the plugin to be validated. It is used to search for and validate examples.
+
+#### `path` (string, `PLUGIN_PATH`)
+
+Where the plugin to lint can be found.
+
+### Optional
+
+#### `readme` (string, `PLUGIN_README`)
+
+The name of the file to validate examples on.
+
+Default: `README.md`
+
+#### `skip-invalid` (boolean, `PLUGIN_SKIP_INVALID`)
+
+Invalid versions are normally reported as failures, turning on this option would change that behaviour.
+
+Default: `false`
+
 ## Usage
 
-You can use this tool via the [Linter Plugin](https://github.com/buildkite-plugins/plugin-linter-buildkite-plugin) or you can add it to your docker-compose.yml file and then use `docker-compose run --rm lint`:
+You should use this tool via the [Linter Plugin](https://github.com/buildkite-plugins/plugin-linter-buildkite-plugin) in your plugin's pipeline.
+
+Alternatively, you can add it to your docker-compose.yml file and then use `docker-compose run --rm lint`:
 
 ```yml
 services:
@@ -35,7 +65,8 @@ docker run \
   --rm \
   -v "$(pwd):/plugin" \
   buildkite/plugin-linter \
-    --id my-org/my-plugin
+    --id my-org/my-plugin \
+    --path README.md
 ```
 
 If your plugin examples use a full git URL, such as `ssh://git@github.com/my-org/example-buildkite-plugin`, then you should specify the full git URL in the `id` argument.

--- a/bin/lint
+++ b/bin/lint
@@ -17,6 +17,12 @@ const argv = require('yargs')
     type: 'string',
     default: 'README.md'
   })
+  .option('skipInvalid', {
+    alias: 'skip-invalid',
+    describe: 'Invalid versions do not cause failures',
+    type: 'boolean',
+    default: false
+  })
   .check(yargs => {
     if (yargs && yargs.id && yargs.id.endsWith('-buildkite-plugin') && yargs.id.indexOf('://') === -1 
         && !yargs.id.startsWith('./') && !yargs.id.startsWith('/') && !yargs.id.startsWith('~/') ) {

--- a/bin/lint
+++ b/bin/lint
@@ -17,8 +17,7 @@ const argv = require('yargs')
     type: 'string',
     default: 'README.md'
   })
-  .option('skipInvalid', {
-    alias: 'skip-invalid',
+  .option('skip-invalid', {
     describe: 'Invalid versions do not cause failures',
     type: 'boolean',
     default: false

--- a/lib/linters/readme-version-number-linter.js
+++ b/lib/linters/readme-version-number-linter.js
@@ -4,7 +4,7 @@ const git = require('isomorphic-git')
 const { compareVersions, validate } = require('compare-versions')
 
 module.exports = async function (argv, tap) {
-  const { id, path: pluginPath, readme, silent } = argv
+  const { id, path: pluginPath, readme, silent, skipInvalid } = argv
 
   const pluginConfigKeyPattern = new RegExp(`${id}#(v?.*):`, 'g')
 
@@ -27,6 +27,7 @@ module.exports = async function (argv, tap) {
   }
 
   const invalidVersionNumbers = []
+  const oldVersionNumbers = []
 
   while (true) {
     const match = pluginConfigKeyPattern.exec(readmeContents)
@@ -34,24 +35,32 @@ module.exports = async function (argv, tap) {
       break
     }
     const version = match[1]
-    if (!validate(version) || compareVersions(version, latestVersion) === -1) {
+    if (!validate(version)) {
       invalidVersionNumbers.push(version)
+    } else if (compareVersions(version, latestVersion) === -1) {
+      oldVersionNumbers.push(version)
     }
   }
 
-  if (!invalidVersionNumbers.length) {
-    if (!silent) {
-      tap.pass(`Readme version numbers are up-to-date (${latestVersion})`)
-    }
-    return true
-  } else {
+  if (oldVersionNumbers.length) {
     if (!silent) {
       tap.fail(`Readme version numbers out of date. Latest is ${latestVersion}`, {
-        'invalid version numbers': invalidVersionNumbers,
+        'outdated version numbers': oldVersionNumbers,
         at: false,
         stack: false
       })
     }
     return false
+  } else if (invalidVersionNumbers.length && !skipInvalid) {
+    if (!silent) {
+      tap.fail(`Found some invalid versions.`,
+               {'invalid version numbers': invalidVersionNumbers})
+    }
+    return false
   }
+
+  if (!silent) {
+    tap.pass(`Readme version numbers are up-to-date (${latestVersion})`)
+  }
+  return true
 }

--- a/lib/linters/readme-version-number-linter.js
+++ b/lib/linters/readme-version-number-linter.js
@@ -47,16 +47,16 @@ module.exports = async function (argv, tap) {
       tap.fail(`Readme version numbers out of date. Latest is ${latestVersion}`, {
         'outdated version numbers': oldVersionNumbers,
         at: null,
-        stack: null,
+        stack: null
       })
     }
     return false
   } else if (invalidVersionNumbers.length && !skipInvalid) {
     if (!silent) {
-      tap.fail(`Found some invalid versions.`, {
+      tap.fail('Found some invalid versions.', {
         'invalid version numbers': invalidVersionNumbers,
         at: null,
-        stack: null,
+        stack: null
       })
     }
     return false

--- a/lib/linters/readme-version-number-linter.js
+++ b/lib/linters/readme-version-number-linter.js
@@ -46,15 +46,18 @@ module.exports = async function (argv, tap) {
     if (!silent) {
       tap.fail(`Readme version numbers out of date. Latest is ${latestVersion}`, {
         'outdated version numbers': oldVersionNumbers,
-        at: false,
-        stack: false
+        at: null,
+        stack: null,
       })
     }
     return false
   } else if (invalidVersionNumbers.length && !skipInvalid) {
     if (!silent) {
-      tap.fail(`Found some invalid versions.`,
-               {'invalid version numbers': invalidVersionNumbers})
+      tap.fail(`Found some invalid versions.`, {
+        'invalid version numbers': invalidVersionNumbers,
+        at: null,
+        stack: null,
+      })
     }
     return false
   }

--- a/test/readme-version-number-linter.test.js
+++ b/test/readme-version-number-linter.test.js
@@ -57,6 +57,34 @@ describe('readme-version-number-linter', () => {
       }, tap))
     })
   })
+  describe('custom readme with invalid version numbers', () => {
+    it('should be valid with the skipInvalid option', async () => {
+      assert(await linter({
+        id: 'custom-readme',
+        path: initGitFixture(path.join(fixtures, 'custom-readme')),
+        readme: 'invalid-version.md',
+        skipInvalid: true,
+        silent: true
+      }, tap))
+    })
+    it('should be invalid with the skipInvalid option turned off', async () => {
+      assert.isFalse(await linter({
+        id: 'custom-readme',
+        path: initGitFixture(path.join(fixtures, 'custom-readme')),
+        readme: 'invalid-version.md',
+        skipInvalid: false,
+        silent: true
+      }, tap))
+    })
+    it('should be invalid without the skipInvalid option', async () => {
+      assert.isFalse(await linter({
+        id: 'custom-readme',
+        path: initGitFixture(path.join(fixtures, 'custom-readme')),
+        readme: 'invalid-version.md',
+        silent: true
+      }, tap))
+    })
+  })
   describe('readme with out of date version numbers and no v prefix', () => {
     it('should be invalid', async () => {
       assert.isFalse(await linter({
@@ -67,7 +95,7 @@ describe('readme-version-number-linter', () => {
       }, tap))
     })
   })
-  describe('readme withan invalid version number', () => {
+  describe('readme with an invalid version tags', () => {
     it('should ignore the invalid', async () => {
       assert(await linter({
         id: 'invalid-sem-ver-tags',

--- a/test/readme-version-number-linter/custom-readme/invalid-version.md
+++ b/test/readme-version-number-linter/custom-readme/invalid-version.md
@@ -1,0 +1,5 @@
+```
+steps:
+  - plugins:
+      - custom-readme#custom-version: ~
+```


### PR DESCRIPTION
Adds a new option `--skip-invalid` to avoid failures when an example contains an invalid version.

While I was at it, I added more documentation on available options and how to use environment variables.

Closes #485 