### PR TITLE
Build image for pushing

### DIFF
--- a/.buildkite/pipeline.deploy.yml
+++ b/.buildkite/pipeline.deploy.yml
@@ -11,6 +11,7 @@ steps:
       docker-login#v3.0.0: ~
       docker-compose#v5.2.0:
         config: docker-compose.prod.yml
+        build: linter
         push:
           - linter:buildkite/plugin-linter
     if: |
@@ -20,6 +21,7 @@ steps:
       docker-login#v3.0.0: ~
       docker-compose#v5.2.0:
         config: docker-compose.prod.yml
+        build: linter
         push:
           - linter:buildkite/plugin-linter:${BUILDKITE_TAG}
     if: |


### PR DESCRIPTION
Since the upgrade to Compose v5+ released images (and `latest`) were not being pushed because they were not built automatically as they were before.