### PR TITLE
Dependencies update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine@sha256:09dbe0a53523c2482d85a037efc6b0e8e8bb16c6f1acf431fe36aa0ebc871c06 as base
+FROM node:lts-alpine@sha256:5144f275bf24e03ec5d8629d72eebb66d403a673b668f8fda0dd01176984a701 as base
 WORKDIR    /src
 ENV        PATH=$PATH:/src/bin PLUGIN_PATH=/plugin
 ADD        . /src/

--- a/bin/lint
+++ b/bin/lint
@@ -1,6 +1,12 @@
 #!/usr/bin/env node
 
-const argv = require('yargs')
+import yargs from 'yargs'
+
+import yaml_linter from '../lib/linters/plugin-yaml-linter.js'
+import example_linter from '../lib/linters/example-linter.js'
+import readme_linter from '../lib/linters/readme-version-number-linter.js'
+
+const argv = yargs(process.argv.slice(2))
   .env('PLUGIN')
   .usage('$0', 'Lint a buildkite plugin')
   .option('id', {
@@ -23,7 +29,7 @@ const argv = require('yargs')
     default: false
   })
   .check(yargs => {
-    if (yargs && yargs.id && yargs.id.endsWith('-buildkite-plugin') && yargs.id.indexOf('://') === -1 
+    if (yargs && yargs.id && yargs.id.endsWith('-buildkite-plugin') && yargs.id.indexOf('://') === -1
         && !yargs.id.startsWith('./') && !yargs.id.startsWith('/') && !yargs.id.startsWith('~/') ) {
       throw new Error(`--id can not end with -buildkite-plugin. Did you mean ${yargs.id.replace(/-buildkite-plugin$/, '')}?`)
     }
@@ -34,12 +40,12 @@ const argv = require('yargs')
   .version(false)
   .argv
 
-const tap = require('tap')
+import { t as tap } from 'tap'
 
 Promise.all([
-  require('../lib/linters/plugin-yaml-linter')(argv, tap),
-  require('../lib/linters/example-linter')(argv, tap),
-  require('../lib/linters/readme-version-number-linter')(argv, tap)
+  yaml_linter(argv, tap),
+  example_linter(argv, tap),
+  readme_linter(argv, tap),
   ])
   .catch((err) => {
     tap.threw(err)

--- a/lib/linters/example-linter.js
+++ b/lib/linters/example-linter.js
@@ -111,7 +111,7 @@ module.exports = async function (argv, tap) {
   }
 
   function extractPluginConfigs (exampleYaml) {
-    const example = yaml.safeLoad(exampleYaml)
+    const example = yaml.load(exampleYaml)
 
     // Some readmes leave off the "steps" key and jump right into an array of
     // commands. In that case, we use the whole example.

--- a/lib/linters/example-linter.js
+++ b/lib/linters/example-linter.js
@@ -1,15 +1,16 @@
-const fs = require('fs')
-const path = require('path')
-const Ajv = require('ajv')
-const yaml = require('js-yaml')
-const pluginYamlParser = require('../plugin-yaml')
+import { Ajv } from 'ajv'
+import { readFileSync } from 'fs'
+import { load } from 'js-yaml'
+import { join } from 'path'
 
-module.exports = async function (argv, tap) {
+import pluginYamlParser from '../plugin-yaml.js'
+
+export default async function (argv, tap) {
   const { id, path: pluginPath, readme, silent } = argv
 
-  const readmePath = path.join(pluginPath, readme)
+  const readmePath = join(pluginPath, readme)
 
-  const readmeContents = fs.readFileSync(readmePath, 'utf8')
+  const readmeContents = readFileSync(readmePath, 'utf8')
   const pluginYaml = pluginYamlParser(pluginPath)
 
   if (!pluginYaml.configuration) {
@@ -111,7 +112,7 @@ module.exports = async function (argv, tap) {
   }
 
   function extractPluginConfigs (exampleYaml) {
-    const example = yaml.load(exampleYaml)
+    const example = load(exampleYaml)
 
     // Some readmes leave off the "steps" key and jump right into an array of
     // commands. In that case, we use the whole example.

--- a/lib/linters/plugin-yaml-linter.js
+++ b/lib/linters/plugin-yaml-linter.js
@@ -1,14 +1,16 @@
-const path = require('path')
-const fs = require('fs')
-const pluginYamlParser = require('../plugin-yaml')
-const yaml = require('js-yaml')
-const Ajv = require('ajv')
+import { Ajv } from 'ajv'
+import { readFileSync } from 'fs'
+import { load } from 'js-yaml'
+import { join } from 'path'
 
-module.exports = async function (argv, tap) {
+import pluginYamlParser from '../plugin-yaml.js'
+
+export default async function (argv, tap) {
   const { path: pluginPath, silent } = argv
   const pluginYaml = pluginYamlParser(pluginPath)
   const ajv = new Ajv({ allErrors: true, strictTypes: false, jsonPropertySyntax: true })
-  const schema = yaml.load(fs.readFileSync(path.join(__dirname, '..', 'plugin-yaml-schema.yml'), 'utf8'))
+  const __dirname = import.meta.dirname;
+  const schema = load(readFileSync(join(__dirname, '..', 'plugin-yaml-schema.yml'), 'utf8'))
   const validator = ajv.compile(schema)
 
   let valid = validator(pluginYaml)

--- a/lib/linters/plugin-yaml-linter.js
+++ b/lib/linters/plugin-yaml-linter.js
@@ -9,7 +9,7 @@ export default async function (argv, tap) {
   const { path: pluginPath, silent } = argv
   const pluginYaml = pluginYamlParser(pluginPath)
   const ajv = new Ajv({ allErrors: true, strictTypes: false, jsonPropertySyntax: true })
-  const __dirname = import.meta.dirname;
+  const __dirname = import.meta.dirname
   const schema = load(readFileSync(join(__dirname, '..', 'plugin-yaml-schema.yml'), 'utf8'))
   const validator = ajv.compile(schema)
 

--- a/lib/linters/plugin-yaml-linter.js
+++ b/lib/linters/plugin-yaml-linter.js
@@ -8,7 +8,7 @@ module.exports = async function (argv, tap) {
   const { path: pluginPath, silent } = argv
   const pluginYaml = pluginYamlParser(pluginPath)
   const ajv = new Ajv({ allErrors: true, strictTypes: false, jsonPropertySyntax: true })
-  const schema = yaml.safeLoad(fs.readFileSync(path.join(__dirname, '..', 'plugin-yaml-schema.yml'), 'utf8'))
+  const schema = yaml.load(fs.readFileSync(path.join(__dirname, '..', 'plugin-yaml-schema.yml'), 'utf8'))
   const validator = ajv.compile(schema)
 
   let valid = validator(pluginYaml)

--- a/lib/linters/readme-version-number-linter.js
+++ b/lib/linters/readme-version-number-linter.js
@@ -1,17 +1,17 @@
-const path = require('path')
-const fs = require('fs')
-const git = require('isomorphic-git')
-const { compareVersions, validate } = require('compare-versions')
+import { compareVersions, validate } from 'compare-versions'
+import { listTags } from 'isomorphic-git'
+import * as fs from 'fs'
+import { join } from 'path'
 
-module.exports = async function (argv, tap) {
+export default async function (argv, tap) {
   const { id, path: pluginPath, readme, silent, skipInvalid } = argv
 
   const pluginConfigKeyPattern = new RegExp(`${id}#(v?.*):`, 'g')
 
-  const readmePath = path.join(pluginPath, readme)
+  const readmePath = join(pluginPath, readme)
   const readmeContents = fs.readFileSync(readmePath, 'utf8')
 
-  const tags = await git.listTags({ fs, dir: pluginPath })
+  const tags = await listTags({ fs, dir: pluginPath })
 
   const sortedTags = tags.sort((t1, t2) => {
     if (!validate(t1)) { return -1 } // invalid t1 < whatever t2 (makes sort stable)

--- a/lib/plugin-yaml.js
+++ b/lib/plugin-yaml.js
@@ -1,9 +1,9 @@
-const fs = require('fs')
-const path = require('path')
-const yaml = require('js-yaml')
+import { readFileSync } from 'fs'
+import { load } from 'js-yaml'
+import { join } from 'path'
 
-module.exports = function (pluginPath) {
-  const yamlPath = path.join(pluginPath, 'plugin.yml')
+export default function (pluginPath) {
+  const yamlPath = join(pluginPath, 'plugin.yml')
 
-  return yaml.load(fs.readFileSync(yamlPath, 'utf8'))
+  return load(readFileSync(yamlPath, 'utf8'))
 }

--- a/lib/plugin-yaml.js
+++ b/lib/plugin-yaml.js
@@ -5,5 +5,5 @@ const yaml = require('js-yaml')
 module.exports = function (pluginPath) {
   const yamlPath = path.join(pluginPath, 'plugin.yml')
 
-  return yaml.safeLoad(fs.readFileSync(yamlPath, 'utf8'))
+  return yaml.load(fs.readFileSync(yamlPath, 'utf8'))
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
         "ajv": "8.17.1",
         "compare-versions": "6.1.1",
         "isomorphic-git": "1.27.1",
-        "js-yaml": "3.14.1",
+        "js-yaml": "4.1.0",
         "tap": "21.0.0",
         "yargs": "17.7.2"
       },
@@ -156,12 +156,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
-    },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -170,18 +164,6 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
@@ -1132,12 +1114,9 @@
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.0",
@@ -2448,12 +2427,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/eslint/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
-    },
     "node_modules/eslint/node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2474,18 +2447,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/eslint/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/eslint/node_modules/json-schema-traverse": {
@@ -2521,18 +2482,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/esquery": {
@@ -3713,12 +3662,11 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
@@ -4129,13 +4077,6 @@
         "node": ">= 14.0.0"
       }
     },
-    "node_modules/mocha/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
-    },
     "node_modules/mocha/node_modules/glob": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
@@ -4155,19 +4096,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/mocha/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/mocha/node_modules/yargs": {
@@ -5594,11 +5522,6 @@
       "version": "3.0.16",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.16.tgz",
       "integrity": "sha512-eWN+LnM3GR6gPu35WxNgbGl8rmY1AEmoMDvL/QD6zYmPWgywxWqJWNdLGT+ke8dKNWrcYgYjPpG5gbTfghP8rw=="
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
     "node_modules/ssri": {
       "version": "10.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "yargs": "17.7.2"
       },
       "devDependencies": {
-        "chai": "4.4.1",
+        "chai": "5.1.1",
         "fs-extra": "11.2.0",
         "mocha": "10.7.0",
         "standard": "17.1.0"
@@ -1200,12 +1200,13 @@
       }
     },
     "node_modules/assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": "*"
+        "node": ">=12"
       }
     },
     "node_modules/async-hook-domain": {
@@ -1468,21 +1469,20 @@
       }
     },
     "node_modules/chai": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
-      "integrity": "sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.1.1.tgz",
+      "integrity": "sha512-pT1ZgP8rPNqUgieVaEY+ryQr6Q4HXNg8Ei9UnLUrjN4IA7dvQC5JB+/kxVcPNDHyBcc/26CXPkbNzq3qwrOEKA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.3",
-        "deep-eql": "^4.1.3",
-        "get-func-name": "^2.0.2",
-        "loupe": "^2.3.6",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.0.8"
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=12"
       }
     },
     "node_modules/chalk": {
@@ -1514,15 +1514,13 @@
       }
     },
     "node_modules/check-error": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
-      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
       "dev": true,
-      "dependencies": {
-        "get-func-name": "^2.0.2"
-      },
+      "license": "MIT",
       "engines": {
-        "node": "*"
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -1714,13 +1712,11 @@
       }
     },
     "node_modules/deep-eql": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
-      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
       "dev": true,
-      "dependencies": {
-        "type-detect": "^4.0.0"
-      },
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -2779,6 +2775,7 @@
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
       "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -3826,12 +3823,13 @@
       }
     },
     "node_modules/loupe": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
-      "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.1.tgz",
+      "integrity": "sha512-edNu/8D5MKVfGVFRhFf8aAxiTM6Wumfz5XsaatSxlD3w4R1d/WEKUTydCdPGbl9K7QG/Ca3GnDV2sIKIpXRQcw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "get-func-name": "^2.0.0"
+        "get-func-name": "^2.0.1"
       }
     },
     "node_modules/lru-cache": {
@@ -4722,12 +4720,13 @@
       }
     },
     "node_modules/pathval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
+      "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": "*"
+        "node": ">= 14.16"
       }
     },
     "node_modules/picomatch": {
@@ -7504,15 +7503,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/type-fest": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "ajv": "8.17.1",
     "compare-versions": "6.1.1",
     "isomorphic-git": "1.27.1",
-    "js-yaml": "3.14.1",
+    "js-yaml": "4.1.0",
     "tap": "21.0.0",
     "yargs": "17.7.2"
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "yargs": "17.7.2"
   },
   "devDependencies": {
-    "chai": "4.4.1",
+    "chai": "5.1.1",
     "fs-extra": "11.2.0",
     "mocha": "10.7.0",
     "standard": "17.1.0"
@@ -17,5 +17,6 @@
   "scripts": {
     "test": "mocha",
     "lint": "standard"
-  }
+  },
+  "type": "module"
 }

--- a/test/example-linter.test.js
+++ b/test/example-linter.test.js
@@ -1,17 +1,20 @@
 /* eslint-env mocha */
 
-const assert = require('chai').assert
-const linter = require('../lib/linters/example-linter')
-const path = require('path')
-const fixtures = path.join(__dirname, 'example-linter')
-const tap = require('tap')
+import { assert } from 'chai'
+import { join } from 'path'
+import { t as tap } from 'tap'
+
+import linter from '../lib/linters/example-linter.js'
+
+const __dirname = import.meta.dirname;
+const fixtures = join(__dirname, 'example-linter')
 
 describe('example-linter', () => {
   describe('valid example', () => {
     it('should be valid', async () => {
       assert(await linter({
         id: 'valid-plugin',
-        path: path.join(fixtures, 'valid-plugin'),
+        path: join(fixtures, 'valid-plugin'),
         silent: true,
         readme: 'README.md'
       }, tap))
@@ -19,7 +22,7 @@ describe('example-linter', () => {
     it('should be valid without v', async () => {
       assert(await linter({
         id: 'valid-plugin',
-        path: path.join(fixtures, 'valid-plugin'),
+        path: join(fixtures, 'valid-plugin'),
         silent: true,
         readme: 'README-with-anything.md'
       }, tap))
@@ -29,7 +32,7 @@ describe('example-linter', () => {
     it('should be valid', async () => {
       assert(await linter({
         id: 'valid-plugin-with-yaml',
-        path: path.join(fixtures, 'valid-plugin-with-yaml'),
+        path: join(fixtures, 'valid-plugin-with-yaml'),
         silent: true,
         readme: 'README.md'
       }, tap))
@@ -39,7 +42,7 @@ describe('example-linter', () => {
     it('should be valid', async () => {
       assert(await linter({
         id: 'zero-config-plugin',
-        path: path.join(fixtures, 'zero-config-plugin'),
+        path: join(fixtures, 'zero-config-plugin'),
         silent: true,
         readme: 'README.md'
       }, tap))
@@ -49,7 +52,7 @@ describe('example-linter', () => {
     it('should be valid', async () => {
       assert(await linter({
         id: 'valid-example-with-group-step',
-        path: path.join(fixtures, 'valid-example-with-group-step'),
+        path: join(fixtures, 'valid-example-with-group-step'),
         silent: true,
         readme: 'README.md'
       }, tap))
@@ -59,7 +62,7 @@ describe('example-linter', () => {
     it('should be valid', async () => {
       assert(await linter({
         id: 'valid-example-without-a-steps-key',
-        path: path.join(fixtures, 'valid-example-without-a-steps-key'),
+        path: join(fixtures, 'valid-example-without-a-steps-key'),
         silent: true,
         readme: 'README.md'
       }, tap))
@@ -69,7 +72,7 @@ describe('example-linter', () => {
     it('should be valid', async () => {
       assert(await linter({
         id: 'valid-example-with-ignored-yml-block',
-        path: path.join(fixtures, 'valid-example-with-ignored-yml-block'),
+        path: join(fixtures, 'valid-example-with-ignored-yml-block'),
         silent: true,
         readme: 'README.md'
       }, tap))
@@ -79,7 +82,7 @@ describe('example-linter', () => {
     it('should be valid with full url', async () => {
       assert(await linter({
         id: 'ssh://git@github.com/my-org/example-buildkite-plugin',
-        path: path.join(fixtures, 'valid-plugin-with-ssh-syntax'),
+        path: join(fixtures, 'valid-plugin-with-ssh-syntax'),
         silent: true,
         readme: 'README.md'
       }, tap))
@@ -87,7 +90,7 @@ describe('example-linter', () => {
     it('should be valid with plugin id', async () => {
       assert(await linter({
         id: 'my-org/example',
-        path: path.join(fixtures, 'valid-plugin-with-ssh-syntax'),
+        path: join(fixtures, 'valid-plugin-with-ssh-syntax'),
         silent: true,
         readme: 'README.md'
       }, tap))
@@ -97,7 +100,7 @@ describe('example-linter', () => {
     it('should be invalid', async () => {
       assert.isFalse(await linter({
         id: 'invalid-plugin',
-        path: path.join(fixtures, 'invalid-examples'),
+        path: join(fixtures, 'invalid-examples'),
         silent: true,
         readme: 'README.md'
       }, tap))
@@ -105,7 +108,7 @@ describe('example-linter', () => {
     it('is missing version', async () => {
       assert.isFalse(await linter({
         id: 'missing-version',
-        path: path.join(fixtures, 'missing-version'),
+        path: join(fixtures, 'missing-version'),
         silent: true,
         readme: 'README.md'
       }, tap))
@@ -115,7 +118,7 @@ describe('example-linter', () => {
     it('should be invalid', async () => {
       assert.isFalse(await linter({
         id: 'valid-plugin',
-        path: path.join(fixtures, 'old-plugins-syntax'),
+        path: join(fixtures, 'old-plugins-syntax'),
         silent: true,
         readme: 'README.md'
       }, tap))
@@ -125,7 +128,7 @@ describe('example-linter', () => {
     it('should work', async () => {
       assert(await linter({
         id: 'custom-readme',
-        path: path.join(fixtures, 'custom-readme'),
+        path: join(fixtures, 'custom-readme'),
         silent: true,
         readme: 'custom-readme.md'
       }, tap))
@@ -135,7 +138,7 @@ describe('example-linter', () => {
     it('should work', async () => {
       assert(await linter({
         id: 'missing-configuration',
-        path: path.join(fixtures, 'missing-configuration'),
+        path: join(fixtures, 'missing-configuration'),
         silent: true,
         readme: 'README.md'
       }, tap))
@@ -145,7 +148,7 @@ describe('example-linter', () => {
     it('should be valid', async () => {
       assert(await linter({
         id: './test/example-linter/valid-local-plugin',
-        path: path.join(fixtures, 'valid-local-plugin'),
+        path: join(fixtures, 'valid-local-plugin'),
         silent: true,
         readme: 'README.md'
       }, tap))

--- a/test/example-linter.test.js
+++ b/test/example-linter.test.js
@@ -6,7 +6,7 @@ import { t as tap } from 'tap'
 
 import linter from '../lib/linters/example-linter.js'
 
-const __dirname = import.meta.dirname;
+const __dirname = import.meta.dirname
 const fixtures = join(__dirname, 'example-linter')
 
 describe('example-linter', () => {

--- a/test/plugin-yaml-linter.test.js
+++ b/test/plugin-yaml-linter.test.js
@@ -1,17 +1,20 @@
 /* eslint-env mocha */
 
-const assert = require('chai').assert
-const linter = require('../lib/linters/plugin-yaml-linter')
-const path = require('path')
-const fixtures = path.join(__dirname, 'plugin-yaml-linter')
-const tap = require('tap')
+import { assert } from 'chai'
+import { join } from 'path'
+import { t as tap } from 'tap'
+
+import linter from '../lib/linters/plugin-yaml-linter.js'
+
+const __dirname = import.meta.dirname;
+const fixtures = join(__dirname, 'plugin-yaml-linter')
 
 describe('plugin-yaml-linter', () => {
   describe('valid plugin', () => {
     it('should be valid', async () => {
       assert(await linter({
         id: 'valid-plugin',
-        path: path.join(fixtures, 'valid-plugin'),
+        path: join(fixtures, 'valid-plugin'),
         silent: true
       }, tap))
     })
@@ -29,7 +32,7 @@ describe('plugin-yaml-linter', () => {
       it('should be invalid', async () => {
         assert.isFalse(await linter({
           name: invalidCase,
-          path: path.join(fixtures, invalidCase),
+          path: join(fixtures, invalidCase),
           silent: true
         }, tap))
       })

--- a/test/plugin-yaml-linter.test.js
+++ b/test/plugin-yaml-linter.test.js
@@ -6,7 +6,7 @@ import { t as tap } from 'tap'
 
 import linter from '../lib/linters/plugin-yaml-linter.js'
 
-const __dirname = import.meta.dirname;
+const __dirname = import.meta.dirname
 const fixtures = join(__dirname, 'plugin-yaml-linter')
 
 describe('plugin-yaml-linter', () => {

--- a/test/readme-version-number-linter.test.js
+++ b/test/readme-version-number-linter.test.js
@@ -1,18 +1,20 @@
 /* eslint-env mocha */
 
-const assert = require('chai').assert
-const path = require('path')
-const fs = require('fs-extra')
-const tap = require('tap')
+import { assert } from 'chai'
+import { copySync } from 'fs-extra/esm'
+import { t as tap } from 'tap'
+import { join } from 'path'
 
-const fixtures = path.join(__dirname, 'readme-version-number-linter')
-const linter = require('../lib/linters/readme-version-number-linter')
+import linter from '../lib/linters/readme-version-number-linter.js'
+
+const __dirname = import.meta.dirname;
+const fixtures = join(__dirname, 'readme-version-number-linter')
 
 // The fixtures are checked as git repos, and then renamed from .git to git so
 // they can be checked in. This just reverses the renames so we can use them as
 // standalone git repos.
 function initGitFixture (dir) {
-  fs.copySync(path.join(dir, 'git'), path.join(dir, '.git'))
+  copySync(join(dir, 'git'), join(dir, '.git'))
   return dir
 }
 
@@ -21,7 +23,7 @@ describe('readme-version-number-linter', () => {
     it('should be valid', async () => {
       assert(await linter({
         id: 'up-to-date',
-        path: initGitFixture(path.join(fixtures, 'up-to-date')),
+        path: initGitFixture(join(fixtures, 'up-to-date')),
         readme: 'README.md',
         silent: true
       }, tap))
@@ -31,7 +33,7 @@ describe('readme-version-number-linter', () => {
     it('should be valid', async () => {
       assert(await linter({
         id: 'future-version',
-        path: initGitFixture(path.join(fixtures, 'future-version')),
+        path: initGitFixture(join(fixtures, 'future-version')),
         readme: 'README.md',
         silent: true
       }, tap))
@@ -41,7 +43,7 @@ describe('readme-version-number-linter', () => {
     it('should be valid', async () => {
       assert(linter({
         id: 'custom-readme',
-        path: initGitFixture(path.join(fixtures, 'custom-readme')),
+        path: initGitFixture(join(fixtures, 'custom-readme')),
         readme: 'custom-readme.md',
         silent: true
       }, tap))
@@ -51,7 +53,7 @@ describe('readme-version-number-linter', () => {
     it('should be invalid', async () => {
       assert.isFalse(await linter({
         id: 'out-of-date',
-        path: initGitFixture(path.join(fixtures, 'out-of-date')),
+        path: initGitFixture(join(fixtures, 'out-of-date')),
         readme: 'README.md',
         silent: true
       }, tap))
@@ -61,7 +63,7 @@ describe('readme-version-number-linter', () => {
     it('should be valid with the skipInvalid option', async () => {
       assert(await linter({
         id: 'custom-readme',
-        path: initGitFixture(path.join(fixtures, 'custom-readme')),
+        path: initGitFixture(join(fixtures, 'custom-readme')),
         readme: 'invalid-version.md',
         skipInvalid: true,
         silent: true
@@ -70,7 +72,7 @@ describe('readme-version-number-linter', () => {
     it('should be invalid with the skipInvalid option turned off', async () => {
       assert.isFalse(await linter({
         id: 'custom-readme',
-        path: initGitFixture(path.join(fixtures, 'custom-readme')),
+        path: initGitFixture(join(fixtures, 'custom-readme')),
         readme: 'invalid-version.md',
         skipInvalid: false,
         silent: true
@@ -79,7 +81,7 @@ describe('readme-version-number-linter', () => {
     it('should be invalid without the skipInvalid option', async () => {
       assert.isFalse(await linter({
         id: 'custom-readme',
-        path: initGitFixture(path.join(fixtures, 'custom-readme')),
+        path: initGitFixture(join(fixtures, 'custom-readme')),
         readme: 'invalid-version.md',
         silent: true
       }, tap))
@@ -89,7 +91,7 @@ describe('readme-version-number-linter', () => {
     it('should be invalid', async () => {
       assert.isFalse(await linter({
         id: 'out-of-date',
-        path: initGitFixture(path.join(fixtures, 'out-of-date')),
+        path: initGitFixture(join(fixtures, 'out-of-date')),
         readme: 'README-No-Version.md',
         silent: true
       }, tap))
@@ -99,7 +101,7 @@ describe('readme-version-number-linter', () => {
     it('should ignore the invalid', async () => {
       assert(await linter({
         id: 'invalid-sem-ver-tags',
-        path: initGitFixture(path.join(fixtures, 'invalid-sem-ver-tags')),
+        path: initGitFixture(join(fixtures, 'invalid-sem-ver-tags')),
         readme: 'README.md',
         silent: true
       }, tap))

--- a/test/readme-version-number-linter.test.js
+++ b/test/readme-version-number-linter.test.js
@@ -7,7 +7,7 @@ import { join } from 'path'
 
 import linter from '../lib/linters/readme-version-number-linter.js'
 
-const __dirname = import.meta.dirname;
+const __dirname = import.meta.dirname
 const fixtures = join(__dirname, 'readme-version-number-linter')
 
 // The fixtures are checked as git repos, and then renamed from .git to git so


### PR DESCRIPTION
## NodeJS base image

Updates NodeJS image to latest LTS (same as #539)

Nothing to call home about as everything worked on that PR

## `js-yaml`

Updates `js-yaml` dependency to 4.1.0 (same as #531).

This was a major update as the `safe` versions of functions were removed as they are the default ones now. Had to rename a few calls here and there but not too complicated

## `chai`

Updates `chai` dev dependency to 5.1.1 (same as #501).

This was a major version upgrade because they removed support for older NodeJS versions and made ESM mandatory. This means that `require` would no longer work and would need replacing with `import` statements. Unfortunately, you can not mix the two so there was a need for a major overhaul of the code around the dependencies.

* all JS files had default exports declared
* all `require` statements were replaced with (mostly) equivalent `import` ones
* parts of the code that used the imports were fixed when/if necessary

Huge props to VSCode for doing most of the tedious changes through automatic conversion of files to ESM-compatible code.