### PR TITLE
Migrate deploy pipeline to the OSS Deploy cluster

### DIFF
--- a/.buildkite/pipeline.deploy.yml
+++ b/.buildkite/pipeline.deploy.yml
@@ -8,21 +8,33 @@ steps:
 
   - label: ":docker: :rocket: Latest"
     plugins:
-      docker-login#v3.0.0: ~
-      docker-compose#v5.4.0:
-        config: docker-compose.prod.yml
-        build: linter
-        push:
-          - linter:buildkite/plugin-linter
+      - aws-assume-role-with-web-identity:
+          role-arn: arn:aws:iam::445615400570:role/pipeline-buildkite-plugin-linter-deploy
+      - aws-ssm#v1.0.0:
+          parameters:
+            BUILDKITE_PLUGIN_DOCKER_LOGIN_USERNAME: /pipelines/buildkite/plugin-linter-deploy/docker-login-username
+            DOCKER_LOGIN_PASSWORD: /pipelines/buildkite/plugin-linter-deploy/docker-login-password
+      - docker-login#v3.0.0: ~
+      - docker-compose#v5.4.0:
+          config: docker-compose.prod.yml
+          build: linter
+          push:
+            - linter:buildkite/plugin-linter
     if: |
       build.branch == 'master'
   - label: ":docker: :rocket: Tag"
     plugins:
-      docker-login#v3.0.0: ~
-      docker-compose#v5.4.0:
-        config: docker-compose.prod.yml
-        build: linter
-        push:
-          - linter:buildkite/plugin-linter:${BUILDKITE_TAG}
+      - aws-assume-role-with-web-identity:
+          role-arn: arn:aws:iam::445615400570:role/pipeline-buildkite-plugin-linter-deploy
+      - aws-ssm#v1.0.0:
+          parameters:
+            BUILDKITE_PLUGIN_DOCKER_LOGIN_USERNAME: /pipelines/buildkite/plugin-linter-deploy/docker-login-username
+            DOCKER_LOGIN_PASSWORD: /pipelines/buildkite/plugin-linter-deploy/docker-login-password
+      - docker-login#v3.0.0: ~
+      - docker-compose#v5.4.0:
+          config: docker-compose.prod.yml
+          build: linter
+          push:
+            - linter:buildkite/plugin-linter:${BUILDKITE_TAG}
     if: |
       build.tag != null


### PR DESCRIPTION
We're slowly migrating open source pipelines into their own clusters. This pattern includes using pipeline-specific OIDC assumable roles for access to any resources needed; and injecting secrets explicitly to steps, using the ssm plugin, rather than using s3 secrets.

The roles and ssm parameters have been created, but the cluster will need to be changed in the pipeline settings before this is merged.