### PR TITLE
fix(deps): update js-yaml to v5 and restore merge key support

### DIFF
--- a/lib/linters/example-linter.js
+++ b/lib/linters/example-linter.js
@@ -112,7 +112,8 @@ export default async function (argv, tap) {
   }
 
   function extractPluginConfigs (exampleYaml) {
-    const example = loadYaml(exampleYaml)
+    // a readme block holding nothing but comments should be skipped, not throw
+    const example = loadYaml(exampleYaml) ?? {}
 
     // Some readmes leave off the "steps" key and jump right into an array of
     // commands. In that case, we use the whole example.

--- a/lib/linters/example-linter.js
+++ b/lib/linters/example-linter.js
@@ -1,9 +1,9 @@
 import { Ajv } from 'ajv'
 import { readFileSync } from 'fs'
-import { load } from 'js-yaml'
 import { join } from 'path'
 
 import pluginYamlParser from '../plugin-yaml.js'
+import loadYaml from '../yaml.js'
 
 export default async function (argv, tap) {
   const { id, path: pluginPath, readme, silent, skipInvalid } = argv
@@ -112,7 +112,7 @@ export default async function (argv, tap) {
   }
 
   function extractPluginConfigs (exampleYaml) {
-    const example = load(exampleYaml)
+    const example = loadYaml(exampleYaml)
 
     // Some readmes leave off the "steps" key and jump right into an array of
     // commands. In that case, we use the whole example.

--- a/lib/linters/plugin-yaml-linter.js
+++ b/lib/linters/plugin-yaml-linter.js
@@ -1,16 +1,16 @@
 import { Ajv } from 'ajv'
 import { readFileSync } from 'fs'
-import { load } from 'js-yaml'
 import { join } from 'path'
 
 import pluginYamlParser from '../plugin-yaml.js'
+import loadYaml from '../yaml.js'
 
 export default async function (argv, tap) {
   const { path: pluginPath, silent } = argv
   const pluginYaml = pluginYamlParser(pluginPath)
   const ajv = new Ajv({ allErrors: true, strictTypes: false, jsonPropertySyntax: true })
   const __dirname = import.meta.dirname
-  const schema = load(readFileSync(join(__dirname, '..', 'plugin-yaml-schema.yml'), 'utf8'))
+  const schema = loadYaml(readFileSync(join(__dirname, '..', 'plugin-yaml-schema.yml'), 'utf8'))
   const validator = ajv.compile(schema)
 
   let valid = validator(pluginYaml)

--- a/lib/linters/plugin-yaml-linter.js
+++ b/lib/linters/plugin-yaml-linter.js
@@ -10,6 +10,9 @@ export default async function (argv, tap) {
   const pluginYaml = pluginYamlParser(pluginPath)
   const ajv = new Ajv({ allErrors: true, strictTypes: false, jsonPropertySyntax: true })
   const __dirname = import.meta.dirname
+  // no `?? {}` here, unlike the two call sites reading user-supplied YAML: ajv
+  // compiles {} into a validator that accepts every plugin, so a schema that
+  // parses to nothing has to throw
   const schema = loadYaml(readFileSync(join(__dirname, '..', 'plugin-yaml-schema.yml'), 'utf8'))
   const validator = ajv.compile(schema)
 

--- a/lib/plugin-yaml.js
+++ b/lib/plugin-yaml.js
@@ -1,9 +1,10 @@
 import { readFileSync } from 'fs'
-import { load } from 'js-yaml'
 import { join } from 'path'
+
+import loadYaml from './yaml.js'
 
 export default function (pluginPath) {
   const yamlPath = join(pluginPath, 'plugin.yml')
 
-  return load(readFileSync(yamlPath, 'utf8'))
+  return loadYaml(readFileSync(yamlPath, 'utf8'))
 }

--- a/lib/plugin-yaml.js
+++ b/lib/plugin-yaml.js
@@ -6,5 +6,6 @@ import loadYaml from './yaml.js'
 export default function (pluginPath) {
   const yamlPath = join(pluginPath, 'plugin.yml')
 
-  return loadYaml(readFileSync(yamlPath, 'utf8'))
+  // an empty plugin.yml should fail schema validation, not abort the lint run
+  return loadYaml(readFileSync(yamlPath, 'utf8')) ?? {}
 }

--- a/lib/yaml.js
+++ b/lib/yaml.js
@@ -1,17 +1,19 @@
-import { CORE_SCHEMA, loadAll, mergeTag } from 'js-yaml'
+import { CORE_SCHEMA, loadAll, mergeTag, YAMLException } from 'js-yaml'
 
 // js-yaml loads with the YAML 1.2 core schema, which leaves out the !!merge
 // (<<) tag that Buildkite pipeline YAML relies on
 const schema = CORE_SCHEMA.withTags(mergeTag)
 
+// Returns undefined for a stream with no documents. Callers parsing
+// user-supplied YAML should default that to {}; callers parsing our own files
+// want it to fail loudly instead.
 export default function (source) {
-  // loadAll, because load throws on a stream with no documents. An empty
-  // plugin.yml should fail schema validation rather than abort the lint run.
+  // loadAll rather than load, which throws when there are no documents
   const documents = loadAll(source, { schema })
 
   if (documents.length > 1) {
-    throw new Error('expected a single YAML document')
+    throw new YAMLException('expected a single document in the stream, but found more')
   }
 
-  return documents[0] ?? {}
+  return documents[0]
 }

--- a/lib/yaml.js
+++ b/lib/yaml.js
@@ -1,9 +1,17 @@
-import { CORE_SCHEMA, load, mergeTag } from 'js-yaml'
+import { CORE_SCHEMA, loadAll, mergeTag } from 'js-yaml'
 
 // js-yaml loads with the YAML 1.2 core schema, which leaves out the !!merge
 // (<<) tag that Buildkite pipeline YAML relies on
 const schema = CORE_SCHEMA.withTags(mergeTag)
 
 export default function (source) {
-  return load(source, { schema })
+  // loadAll, because load throws on a stream with no documents. An empty
+  // plugin.yml should fail schema validation rather than abort the lint run.
+  const documents = loadAll(source, { schema })
+
+  if (documents.length > 1) {
+    throw new Error('expected a single YAML document')
+  }
+
+  return documents[0] ?? {}
 }

--- a/lib/yaml.js
+++ b/lib/yaml.js
@@ -8,7 +8,7 @@ const schema = CORE_SCHEMA.withTags(mergeTag)
 // user-supplied YAML should default that to {}; callers parsing our own files
 // want it to fail loudly instead.
 export default function (source) {
-  // loadAll rather than load, which throws when there are no documents
+  // load() throws on a stream with no documents, loadAll() returns []
   const documents = loadAll(source, { schema })
 
   if (documents.length > 1) {

--- a/lib/yaml.js
+++ b/lib/yaml.js
@@ -1,0 +1,9 @@
+import { CORE_SCHEMA, load, mergeTag } from 'js-yaml'
+
+// js-yaml loads with the YAML 1.2 core schema, which leaves out the !!merge
+// (<<) tag that Buildkite pipeline YAML relies on
+const schema = CORE_SCHEMA.withTags(mergeTag)
+
+export default function (source) {
+  return load(source, { schema })
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
         "ajv": "8.20.0",
         "compare-versions": "6.1.1",
         "isomorphic-git": "1.40.0",
-        "js-yaml": "4.3.0",
+        "js-yaml": "5.2.2",
         "tap": "21.7.5",
         "yargs": "18.0.0"
       },
@@ -170,6 +170,29 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
@@ -3148,6 +3171,29 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/eslint/node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/eslint/node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -4737,9 +4783,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
+      "integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
       "funding": [
         {
           "type": "github",
@@ -4755,7 +4801,7 @@
         "argparse": "^2.0.1"
       },
       "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/json-parse-better-errors": {
@@ -5281,6 +5327,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mocha/node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/mocha/node_modules/readdirp": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "ajv": "8.20.0",
     "compare-versions": "6.1.1",
     "isomorphic-git": "1.40.0",
-    "js-yaml": "4.3.0",
+    "js-yaml": "5.2.2",
     "tap": "21.7.5",
     "yargs": "18.0.0"
   },

--- a/test/example-linter.test.js
+++ b/test/example-linter.test.js
@@ -68,6 +68,16 @@ describe('example-linter', () => {
       }, tap))
     })
   })
+  describe('valid example with merge keys', () => {
+    it('should be valid', async () => {
+      assert(await linter({
+        id: 'valid-example-with-merge-keys',
+        path: join(fixtures, 'valid-example-with-merge-keys'),
+        silent: true,
+        readme: 'README.md'
+      }, tap))
+    })
+  })
   describe('valid example with ignored yml block', () => {
     it('should be valid', async () => {
       assert(await linter({

--- a/test/example-linter/valid-example-with-ignored-yml-block/README.md
+++ b/test/example-linter/valid-example-with-ignored-yml-block/README.md
@@ -13,3 +13,7 @@ some:
     yaml:
       block: ~
 ```
+
+```yml
+# just a comment, nothing to lint
+```

--- a/test/example-linter/valid-example-with-merge-keys/README.md
+++ b/test/example-linter/valid-example-with-merge-keys/README.md
@@ -1,0 +1,24 @@
+# Example
+
+Merging a whole step:
+
+```yml
+common: &common
+  plugins:
+    - valid-example-with-merge-keys#v1.2.3:
+        option: value
+steps:
+  - <<: *common
+```
+
+Merging into the plugin configuration:
+
+```yml
+defaults: &defaults
+  option: value
+steps:
+  - plugins:
+      - valid-example-with-merge-keys#v1.2.3:
+          <<: *defaults
+          other: thing
+```

--- a/test/example-linter/valid-example-with-merge-keys/plugin.yml
+++ b/test/example-linter/valid-example-with-merge-keys/plugin.yml
@@ -1,0 +1,7 @@
+configuration:
+  properties:
+    option:
+      type: string
+    other:
+      type: string
+  additionalProperties: false

--- a/test/plugin-yaml-linter.test.js
+++ b/test/plugin-yaml-linter.test.js
@@ -20,7 +20,8 @@ describe('plugin-yaml-linter', () => {
     })
   });
 
-  ['invalid-sub-property',
+  ['empty-plugin-yml',
+    'invalid-sub-property',
     'missing-name',
     'missing-description',
     'missing-author',

--- a/test/plugin-yaml-linter/empty-plugin-yml/plugin.yml
+++ b/test/plugin-yaml-linter/empty-plugin-yml/plugin.yml
@@ -1,0 +1,1 @@
+# this plugin.yml has no content yet

--- a/test/plugin-yaml.test.js
+++ b/test/plugin-yaml.test.js
@@ -1,0 +1,24 @@
+/* eslint-env mocha */
+
+import { assert } from 'chai'
+import { join } from 'path'
+
+import pluginYamlParser from '../lib/plugin-yaml.js'
+
+const __dirname = import.meta.dirname
+const fixtures = join(__dirname, 'plugin-yaml')
+
+describe('plugin-yaml', () => {
+  it('parses a plugin.yml', () => {
+    const parsed = pluginYamlParser(join(fixtures, 'valid-plugin'))
+
+    assert.equal(parsed.name, 'A plugin')
+    assert.deepEqual(parsed.configuration.properties, { option: { type: 'string' } })
+  })
+
+  // an empty file has to reach ajv as {} so it fails on the required keys,
+  // rather than as undefined, which ajv happily validates
+  it('parses a plugin.yml with no content as an empty object', () => {
+    assert.deepEqual(pluginYamlParser(join(fixtures, 'empty-plugin-yml')), {})
+  })
+})

--- a/test/plugin-yaml/empty-plugin-yml/plugin.yml
+++ b/test/plugin-yaml/empty-plugin-yml/plugin.yml
@@ -1,0 +1,1 @@
+# this plugin.yml has no content yet

--- a/test/plugin-yaml/valid-plugin/plugin.yml
+++ b/test/plugin-yaml/valid-plugin/plugin.yml
@@ -1,0 +1,8 @@
+name: A plugin
+description: A great plugin
+author: github.com/buildkite
+requirements: []
+configuration:
+  properties:
+    option:
+      type: string

--- a/test/yaml.test.js
+++ b/test/yaml.test.js
@@ -69,7 +69,7 @@ config:
   })
 
   // The loader deliberately sticks to YAML 1.2 core resolution rather than
-  // YAML11_SCHEMA, so these two are the trade-offs we accepted
+  // YAML11_SCHEMA, so these are the trade-offs we accepted
   describe('yaml 1.2 core resolution', () => {
     it('leaves a bare date as a string', () => {
       // v4 built a Date, which never satisfied an Ajv `type: string`

--- a/test/yaml.test.js
+++ b/test/yaml.test.js
@@ -48,21 +48,23 @@ config:
     })
   })
 
+  // Deliberately undefined rather than {}, so that parsing one of our own
+  // files down to nothing fails loudly instead of validating everything
   describe('empty documents', () => {
-    it('returns an empty object for an empty string', () => {
-      assert.deepEqual(loadYaml(''), {})
+    it('returns undefined for an empty string', () => {
+      assert.isUndefined(loadYaml(''))
     })
 
-    it('returns an empty object for whitespace only', () => {
-      assert.deepEqual(loadYaml('   \n\n'), {})
+    it('returns undefined for whitespace only', () => {
+      assert.isUndefined(loadYaml('   \n\n'))
     })
 
-    it('returns an empty object for comments only', () => {
-      assert.deepEqual(loadYaml('# nothing to see here\n'), {})
+    it('returns undefined for comments only', () => {
+      assert.isUndefined(loadYaml('# nothing to see here\n'))
     })
 
-    it('returns an empty object for a bare document marker', () => {
-      assert.deepEqual(loadYaml('---\n'), {})
+    it('returns null for a bare document marker', () => {
+      assert.isNull(loadYaml('---\n'))
     })
   })
 
@@ -85,7 +87,7 @@ config:
     })
 
     it('throws on more than one document', () => {
-      assert.throws(() => loadYaml('steps: []\n---\nsteps: []\n'))
+      assert.throws(() => loadYaml('steps: []\n---\nsteps: []\n'), /expected a single document/)
     })
   })
 })

--- a/test/yaml.test.js
+++ b/test/yaml.test.js
@@ -1,0 +1,60 @@
+/* eslint-env mocha */
+
+import { assert } from 'chai'
+
+import loadYaml from '../lib/yaml.js'
+
+describe('yaml', () => {
+  describe('merge keys', () => {
+    it('merges an aliased mapping into a step', () => {
+      const result = loadYaml(`common: &common
+  plugins:
+    - example#v1.0.0:
+        option: value
+steps:
+  - <<: *common
+`)
+
+      assert.deepEqual(result.steps, [{
+        plugins: [{ 'example#v1.0.0': { option: 'value' } }]
+      }])
+    })
+
+    it('merges an aliased mapping into a plugin config', () => {
+      const result = loadYaml(`defaults: &defaults
+  option: value
+steps:
+  - plugins:
+      - example#v1.0.0:
+          <<: *defaults
+          other: thing
+`)
+
+      assert.deepEqual(result.steps[0].plugins[0]['example#v1.0.0'], {
+        option: 'value',
+        other: 'thing'
+      })
+    })
+
+    it('lets later keys override the merged ones', () => {
+      const result = loadYaml(`defaults: &defaults
+  option: from-anchor
+config:
+  <<: *defaults
+  option: from-config
+`)
+
+      assert.deepEqual(result.config, { option: 'from-config' })
+    })
+  })
+
+  describe('invalid input', () => {
+    it('throws on a syntax error', () => {
+      assert.throws(() => loadYaml('steps:\n\t- command: test\n'), /tab characters/)
+    })
+
+    it('throws on more than one document', () => {
+      assert.throws(() => loadYaml('steps: []\n---\nsteps: []\n'))
+    })
+  })
+})

--- a/test/yaml.test.js
+++ b/test/yaml.test.js
@@ -66,6 +66,19 @@ config:
     })
   })
 
+  // The loader deliberately sticks to YAML 1.2 core resolution rather than
+  // YAML11_SCHEMA, so these two are the trade-offs we accepted
+  describe('yaml 1.2 core resolution', () => {
+    it('leaves a bare date as a string', () => {
+      // v4 built a Date, which never satisfied an Ajv `type: string`
+      assert.strictEqual(loadYaml('when: 2026-07-30\n').when, '2026-07-30')
+    })
+
+    it('throws on yaml 1.1 tags outside the core schema', () => {
+      assert.throws(() => loadYaml('!!set { a, b }\n'), /unknown mapping tag/)
+    })
+  })
+
   describe('invalid input', () => {
     it('throws on a syntax error', () => {
       assert.throws(() => loadYaml('steps:\n\t- command: test\n'), /tab characters/)

--- a/test/yaml.test.js
+++ b/test/yaml.test.js
@@ -48,6 +48,24 @@ config:
     })
   })
 
+  describe('empty documents', () => {
+    it('returns an empty object for an empty string', () => {
+      assert.deepEqual(loadYaml(''), {})
+    })
+
+    it('returns an empty object for whitespace only', () => {
+      assert.deepEqual(loadYaml('   \n\n'), {})
+    })
+
+    it('returns an empty object for comments only', () => {
+      assert.deepEqual(loadYaml('# nothing to see here\n'), {})
+    })
+
+    it('returns an empty object for a bare document marker', () => {
+      assert.deepEqual(loadYaml('---\n'), {})
+    })
+  })
+
   describe('invalid input', () => {
     it('throws on a syntax error', () => {
       assert.throws(() => loadYaml('steps:\n\t- command: test\n'), /tab characters/)


### PR DESCRIPTION
Supersedes #733, which this branch builds on. The first commit is Renovate's unmodified bump and the rest is the code that bump turns out to need, so #733 can be closed in favour of this.

## Why the bump needs code changes

js-yaml v5 changes `load()` to use the YAML 1.2 `CORE_SCHEMA`, which does not include the `!!merge` (`<<`) tag. Merge keys are valid Buildkite pipeline YAML and appear in Buildkite's own plugin documentation, so readmes using them silently stop validating. Running the real linter against the same fixture under both versions:

```
js-yaml 4.3.0: All the readme config examples are valid (2 found)   -> pass
js-yaml 5.2.2: errors: [{ keyword: "additionalProperties",
                          params: { additionalProperty: "<<" } }]   -> fail
```

There are two failure modes. A merge inside a plugin config trips `additionalProperties: false`, which `lib/plugin-yaml-schema.yml` recommends plugin authors set. A merge at the step level hides the plugin entirely, so the linter reports "No readme config examples found" and points the author at their `--id` flag rather than at the real cause.

This example passes on master and fails on the bare bump:

```yaml
common: &common
  plugins:
    - my-plugin#v1.0.0:
        option: value
steps:
  - <<: *common
```

## What changed

`lib/yaml.js` is new and is now the only module that imports js-yaml, so the dialect is decided in one place instead of at three call sites that can drift. It loads with `CORE_SCHEMA.withTags(mergeTag)`, the fix the upstream migration guide recommends.

The schema choice is deliberate, and not for the reason I first assumed. `YAML11_SCHEMA` is further from v4 than the core schema is, not closer: v4's `DEFAULT_SCHEMA` never resolved `yes` as a boolean or `017` as octal, but v5's `YAML11_SCHEMA` does.

| input | v4 `DEFAULT_SCHEMA` | `CORE_SCHEMA.withTags(mergeTag)` | `YAML11_SCHEMA` |
| --- | --- | --- | --- |
| `option: yes` | `"yes"` | `"yes"` | `true` |
| `option: 017` | `17` | `17` | `15` |
| `option: 1:30` | `"1:30"` | `"1:30"` | `90` |
| `option: 1_000` | `"1_000"` | `"1_000"` | `1000` |

Those are silent value changes rather than errors, and `yes`/`no` as a plugin option value is idiomatic. `YAML11_SCHEMA` also keeps coercing bare dates into `Date` objects, which never satisfy an Ajv `type: string`, and Buildkite hands plugin config to hooks as strings anyway.

The trade-off going the other way is that explicit YAML 1.1 tags (`!!set`, `!!binary`, `!!timestamp`, `!!omap`, `!!pairs`) now throw, `0b101` resolves as a string rather than `5`, and YAML complex keys throw where v4 coerced them to `"[object Object]"` (a value starting with `{{`, as in an unquoted `command: {{matrix}}`; the quoted form is unaffected). None of those appear across 235 readme yaml blocks and 34 plugin.yml files in the 40 plugin repos I checked. A `YAML11_SCHEMA` swap fails two tests, so changing the schema later cannot happen silently.

v5 also throws on input containing no documents, where v4 returned `undefined`. The loader reports that as-is and the two call sites reading user-supplied YAML default it to `{}`. The schema load in `plugin-yaml-linter.js` deliberately does not, so an emptied `plugin-yaml-schema.yml` fails loudly rather than compiling to `{}` and passing every plugin it sees.

One incidental improvement: an empty `plugin.yml` now reports "plugin.yml fails schema validation", which neither v4 nor the bare bump managed. Ajv accepts `null` and `undefined` against the schema, so v4 only ever failed on the later configuration check.

## Testing

33 tests to 48, covering the loader, `lib/plugin-yaml.js`, which had no tests of its own, and readme fixtures exercising both merge patterns. Each new test was confirmed failing before the fix it covers.

Beyond the suite, I ran `bin/lint` against every plugin in a local buildkite-plugins checkout under both this branch and master with js-yaml 4.3.0. The output is byte identical: 34 plugins, 101 assertions. A parse-level differential over 235 readme yaml blocks and 34 plugin.yml files likewise shows no divergence from v4.

I also checked that enabling the merge tag does not reintroduce unbounded merge amplification. A payload merging 200 anchors of 60 keys each is rejected with `merge keys exceeded maxTotalMergeKeys (10000)`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency major bump plus centralized parsing changes affect all plugin and readme YAML validation; behavior is well covered by new tests but any subtle v4/v5 schema differences could affect edge-case plugins.
> 
> **Overview**
> Bumps **js-yaml** to **5.2.2** and routes all YAML parsing through a new **`lib/yaml.js`** helper so dialect and v5 behavior are handled in one place.
> 
> The loader uses YAML 1.2 **core** schema plus the **`<<` merge** tag (restored for Buildkite pipeline/readme examples), **`loadAll`** instead of **`load`** so empty streams return **`undefined`** instead of throwing, and rejects multi-document streams. User-facing inputs (`plugin.yml`, readme blocks) coerce empty parses to **`{}`** so linting reports schema/example errors instead of crashing; comment-only readme blocks are skipped the same way.
> 
> **`plugin-yaml-linter`** still loads the schema without defaulting empty content, so a broken schema file fails loudly. Empty **`plugin.yml`** now surfaces as schema validation failure rather than slipping past Ajv.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a468377f6afe8c0b61b7425550564083a42eb542. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->